### PR TITLE
docs: Fix git defaultdir

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -3,6 +3,7 @@
   "url": "docs.sigstore.dev",
   "layout": "default",
   "defaultBranch": "docs",
+  "defaultDir": "",
   "logo": {
     "light": "/logo-light.svg",
     "dark": "/logo-dark.svg"


### PR DESCRIPTION
Thanks helpful docs.

This PR fixes broken links `Edit this page on GitHub` on <https://docs.sigstore.dev>.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
