### PR TITLE
Redirect old explainer page to new one

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
-/* /index.html 200
+/*                 /index.html     200
+/what_is_sigstore  /how-it-works   301


### PR DESCRIPTION
Using netlify `_redirects`, cf. https://docs.netlify.com/routing/redirects/redirect-options/.

Closes #60
