### PR TITLE
rekor: faq: fix 404 to pluggable types

### DIFF
--- a/content/en/faq.md
+++ b/content/en/faq.md
@@ -25,4 +25,4 @@ Public blockchains often end up using a centralized entry point for canonicaliza
 
 ## Can I get Rekor to work with my X format, framework standard?
 
-- Yes. Using plugable types you can create your own manifest layout and send it to Rekor. Head over to [plugable types](/docs/plugable_types/)
+- Yes. Using plugable types you can create your own manifest layout and send it to Rekor. Head over to [plugable types](/rekor/plugable-types/)


### PR DESCRIPTION
The URL was wrong. The correct URL is https://docs.sigstore.dev/rekor/plugable-types

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
