### PR TITLE
content: fix twitter name to projectsigstore

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -9,5 +9,5 @@
     "dark": "/logo-dark.svg"
   },
   "github": "sigstore/sigstore-website",
-  "twitter": "@sigstore"
+  "twitter": "@projectsigstore"
 }


### PR DESCRIPTION
Fix Twitter name to `@projectsigstore`.

#### Summary

The `@sigstore` account is not sigstore official account.

#### Ticket Link

N/A

#### Release Note

?