### PR TITLE
Drop French index

### DIFF
--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -1,7 +1,0 @@
----
-title: 'Overview'
-description: 'Intro text'
-version: 1.4
-category: 'About sigstore'
-position: 1
----

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,11 +3,6 @@ import theme from '@nuxt/content-theme-docs'
 export default theme({
   i18n: {
     locales: () => [{
-      code: 'fr',
-      iso: 'fr-FR',
-      file: 'fr-FR.js',
-      name: 'Français'
-    }, {
       code: 'en',
       iso: 'en-US',
       file: 'en-US.js',


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Since it is empty (for now) the website seems empty when opening it with a browser sending `fr` in the Accept-Language header. Switching to English to access the content is still possible but not really obvious at first.

![image](https://user-images.githubusercontent.com/737767/146927665-1a48221f-d652-42c0-a9c3-5d31cbcd527d.png)
