### PR TITLE
removed typo/double word in further_usage.md

### DIFF
--- a/content/en/cosign/further_usage.md
+++ b/content/en/cosign/further_usage.md
@@ -137,7 +137,7 @@ Rough Idea:
 * We can sign the full set of ordered base layers, and attach that signature as an annotation to
   the **last** layer in the resulting child image.
 
-This example manifest manifest represents an image that has been built from a base image with two
+This example manifest represents an image that has been built from a base image with two
 layers.
 One additional layer is added, forming the final image.
 


### PR DESCRIPTION
Signed-off-by: Stephen Morgan <steve@rebelops.io>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Stumbled upon a typo in the Cosign documentation. I removed the double typed word `manifest`.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes
N/A
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Bug fixes/typo in Cosign documentation.
```
