### PR TITLE
Bump Go version required for Rekor.

### DIFF
--- a/content/en/rekor/overview.md
+++ b/content/en/rekor/overview.md
@@ -26,7 +26,7 @@ There are a few ways to deploy a Rekor Server:
 
 ### Prerequisites
 
-You will need golang version 1.15 or greater and a `$GOPATH` set.
+You will need golang version 1.16 or greater and a `$GOPATH` set.
 
 If you want to perform fast queries you will need to add redis, otherwise you must pass the `--enable_retrieve_api=false`
 flag when running `rekor-server` in the later steps of this page.


### PR DESCRIPTION
CI tests [using 1.17](https://github.com/sigstore/rekor/blob/d31235c273e4dc16587fb38970d1e4c0f4d6e26e/Dockerfile#L33) (the GitHub actions parse the Dockerfile to extract the Go version), and `go.mod` [currently uses 1.16](https://github.com/sigstore/rekor/blob/d31235c273e4dc16587fb38970d1e4c0f4d6e26e/go.mod#L3).

We should probably make all of these match eventually, but for now this definitely builds fine.