### PR TITLE
Updated directory name for rekor-server in documentation

### DIFF
--- a/content/en/rekor/overview.md
+++ b/content/en/rekor/overview.md
@@ -75,7 +75,7 @@ trillian_log_signer --logtostderr --force_master --http_endpoint=localhost:8190 
 #### Build Rekor Server
 
 ```
-cd $GOPATH/src/github.com/sigstore/rekor/cmd/server
+cd $GOPATH/src/github.com/sigstore/rekor/cmd/rekor-server
 go build -v -o rekor-server
 cp rekor-server /usr/local/bin/
 ```


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Fixed documentation instructions for Rekor installation with the wrong directory name (rekor vs. rekor-service). This was previously updated in an earlier part of the instructions but not the latter (https://github.com/sigstore/sigstore-website/pull/102/commits/ffb0d1a274bcd77ab46c09222ef7b86411665df9).
Docs Page: https://docs.sigstore.dev/rekor/overview
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/sigstore-website/issues/100

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
None
```
