### PR TITLE
Add installation instructions for cosign and sget on Alpine Linux edge

### DIFF
--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -24,6 +24,17 @@ If you are using Arch Linux, you can install `cosign` by running:
 
     $ pacman -S cosign
 
+## Alpine Linux
+
+If you are using Alpine Linux edge, with the community repository enabled,
+you can install `cosign` by running:
+
+    $ apk add cosign
+
+The `sget` tool is also available:
+
+    $ apk add sget
+
 ## Nix
 
 If you are using Nix, you can install `cosign` by running:


### PR DESCRIPTION
#### Summary
This pull request adds installation instructions for `cosign` and `sget` on Alpine Linux edge (which will become Alpine Linux 3.16 in May).

#### Release Note
NONE