### PR TITLE
Add support page

### DIFF
--- a/content/en/support.md
+++ b/content/en/support.md
@@ -1,0 +1,34 @@
+---
+title: 'Get Help'
+description: ''
+category: 'Help'
+position: 902
+---
+
+If you were not able to find the relevant information to solve your issue, you can still get help from the `sigstore` community!
+
+This page describe how you could get in touch with us to get support.
+
+# Help from the community
+
+Sigstore has a [Slack community][sc]. Please post any support request in `#general` channel.
+
+# Help from project maintainers
+
+Each repository has a `CODEOWNERS` file describing current maintainers. Join our Slack channel and get in touch with them.
+
+- [`cosign` maintainers][cosign]
+- [`fulcio` maintainers][fulcio]
+- [`rekor` maintainers][rekor]
+- [`sigstore` library maintainers][sigstore]
+
+[cosign]: https://github.com/sigstore/cosign/blob/main/CODEOWNERS
+[fulcio]: https://github.com/sigstore/fulcio/blob/main/CODEOWNERS
+[rekor]: https://github.com/sigstore/rekor/blob/main/CODEOWNERS
+[sigstore]: https://github.com/sigstore/sigstore/blob/main/CODEOWNERS
+
+# Asking questions
+
+We welcome questions! You can either join the [Slack community][sc] and post them on `#general` channel or open a GitHub issue in the relevant repository.
+
+[sc]: https://docs.sigstore.dev/community#slack


### PR DESCRIPTION
Add support page to documentation website, with information on how to get help from community and project maintainers.

Closes https://github.com/sigstore/sigstore-website/issues/113

