### PR TITLE
Attestation example fix

### DIFF
--- a/content/en/cosign/attestation.md
+++ b/content/en/cosign/attestation.md
@@ -10,7 +10,7 @@ defined [here](https://github.com/in-toto/attestation).
 You can create and sign one from a local predicate file using the following commands:
 
 ```shell
-$ cosign attest --predicate <file> --key cosign.pub <image>
+$ cosign attest --predicate <file> --key cosign.key <image>
 ```
 
 All of the standard key management systems are supported. Payloads are signed using the DSSE signing spec,


### PR DESCRIPTION
The example for using the `attest` command should be using the example private key name (`cosign.key`) for the key arg

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

Attestation example command key reference 
