### PR TITLE
Correct the cosigned namespace include label 

### DIFF
--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -87,7 +87,7 @@ kind: Namespace
 metadata:
   name: my-secure-namespace
   labels:
-    cosigned.sigstore.dev: true
+    cosigned.sigstore.dev/include: "true"
   ...
 ```
 


### PR DESCRIPTION
I came across cosigned today and managed to get it running in my cluster.

Currently the webhook in the helm chart has the following namespaceSelector. 

```
  namespaceSelector:
    matchExpressions:
    - key: webhooks.knative.dev/exclude
      operator: DoesNotExist
    - key: cosigned.sigstore.dev/include
      operator: In
      values:
      - "true"
```

First i used the example from the docs (`cosigned.sigstore.dev=true`) which was obviously wrong. Maybe this was a copy & paste error in #138 or it was changed recently.
