### PR TITLE
Add documentation for attestations & CIP policy.

### DIFF
--- a/content/en/cosign/kubernetes.md
+++ b/content/en/cosign/kubernetes.md
@@ -67,7 +67,9 @@ kubectl label namespace my-secure-namespace cosigned.sigstore.dev/include=true
 ### Admission of Images
 
 An image is admitted after it has been validated against all `ClusterImagePolicy` that matched the digest of the image
-and that there was at least one valid signature obtained from the authorities provided in each of the matched `ClusterImagePolicy`.
+and that there was at least one valid signature or attestation obtained from the authorities provided in each of the matched `ClusterImagePolicy`.
+So each `ClusterImagePolicy` that matches is `AND` for admission, and within each `ClusterImagePolicy` authorities
+are `ON`.
 
 See the [Configuring Image Pattern](#configuring-image-patterns) for more information.
 
@@ -75,22 +77,22 @@ If no policy is matched against the image digest, the [deprecated cosigned valid
 
 An example of an allowed admission would be:
 1. If the image matched against `policy1` and `policy3`
-1. A valid signature was obtained for `policy1` with at least one of the `policy1` authorities
-1. A valid signature was obtained for `policy3` with at least one of the `policy3` authorities
+1. A valid signature or attestation was obtained for `policy1` with at least one of the `policy1` authorities
+1. A valid signature or attestation was obtained for `policy3` with at least one of the `policy3` authorities
 1. The image is admitted
 
 An example of a denied admission would be:
 1. If the image matched against `policy1` and `policy2`
-1. A valid signature was obtained for `policy1` with at least one of the `policy1` authorities
-1. No valid signature was obtained for `policy2` with at least one of the `policy2` authorities
+1. A valid signature or attestation was obtained for `policy1` with at least one of the `policy1` authorities
+1. No valid signature or attestation was obtained for `policy2` with at least one of the `policy2` authorities
 1. The image is not admitted
 
 An example of no policy matched:
 1. If the image does not match against any policy
 1. Fallback to [deprecated cosigned validation behavior](#deprecated-cosigned-validation-behavior)
 1. Validation will be attempted against the secret defined under `cosign.secretKeyRef.name` during helm installation.
-  1. If a valid signature is obtained, image is admitted
-  1. If no valid signature is obtained, image is denied
+  1. If a valid signature or attestation is obtained, image is admitted
+  1. If no valid signature or attestation is obtained, image is denied
 
 ### Configuring Cosigned ClusterImagePolicy
 
@@ -103,10 +105,16 @@ A policy is enforced when an image pattern for the policy is matched against the
 The `ClusterImagePolicy` specifies `spec.images` which specifies a list of `glob` and/or `regex` matching patterns.
 These matching patterns will be matched against the image digest of PodSpec resources attempting to be deployed.
 
-**Note:** `glob` currently only supports a single trailing wildcard `*` character.
+Glob uses golang [filepath](https://pkg.go.dev/path/filepath#Match) semantics for
+matching the images against. To make it easier to specify images, there are few
+defaults when an image is matched, namely:
+ * If there is no host in the glob pattern `index.docker.io` is used for the host. This allows
+ users to specify commonly found images from Docker simply as myproject/nginx instead of inded.docker.io/myproject/nginx
+ * If the image is specified without multiple path elements (so not separated by `/`), then `library` is defaulted. For example
+ specifying `busybox` will result in library/busybox. And combined with above, will result in match being made against `index.docker.io/library/busybox`.
 
+A sample of a `ClusterImagePolicy` which matches against all images using glob:
 
-A sample of a `ClusterImagePolicy` which matches against all images:
 ```yaml
 apiVersion: cosigned.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
@@ -115,6 +123,17 @@ metadata:
 spec:
   images:
   - glob: "*"
+```
+
+and with regex:
+
+```yaml
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
   - regex: ".*"
 ```
 
@@ -156,7 +175,6 @@ Each `key` authority can contain these properties:
 When a policy is selected to be evaluated against the matched image, the authorities will be used to validate signatures.
 If at least one authority is satisfied and a signature is validated, the policy is validated.
 
-
 Authorities can be `keyless` specifications. For example:
 
 ```yaml
@@ -186,8 +204,8 @@ Each `keyless` authority can contain these properties:
   - `secretRef.name`: specifies the secret location name in the same namespace where `cosigned` is installed. <br/>The first key value will be used in the secret for the `ca-cert`.
   - `data`: specifies the inline certificate data
 - `keyless.identities`: Identity may contain an array of `issuer` and/or the `subject` found in the transparency log. Either field supports a pattern glob.
-  - `issuer`: specifies the issuer found in the transparency log. Pattern glob are supported.
-  - `subject`: specifies the subject found in the transparency log. Pattern glob are supported.
+  - `issuer`: specifies the issuer found in the transparency log. Regex patterns are supported.
+  - `subject`: specifies the subject found in the transparency log. Regex patterns are supported.
 
 #### Configuring Remote Signature Location
 
@@ -230,6 +248,163 @@ spec:
         url: https://fulcio.example.com
       tlog:
         url: https://rekor.example.com
+```
+
+#### Configuring policy that validates attestations
+
+Just like with `cosign` CLI you can verify attestations (using `verify-attestation`),
+you can configure policies to validate that a particular attestation signed by
+a trusted authority. You do this by using `attestations` array within an `authorities`
+section. For example, to configure that a `custom` predicate has to present and
+attested by the specified `issuer` and `subject`, and the actual `Data` section
+of the predicate matches the string `foobar e2e test`:
+
+```yaml
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-keyless-with-attestations
+spec:
+  images:
+  - glob: registry.local:5000/cosigned/demo*
+  authorities:
+  - name: verify custom attestation
+    keyless:
+      url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuer: .*kubernetes.default.*
+        subject: .*kubernetes.io/namespaces/default/serviceaccounts/default
+    ctlog:
+      url: http://rekor.rekor-system.svc
+    attestations:
+    - name: custom-match-predicate
+      predicateType: custom
+      policy:
+        type: cue
+        data: |
+          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicate: Data: "foobar e2e test"
+```
+
+`policy` is optional and if left out, only the existence of the attestation is
+verified.
+
+#### Configuring policy at the `ClusterImagePolicy` level.
+
+As discussed earlier, by specifying multiple `ClusterImagePolicy` creates an `AND`
+clause so that each `ClusterImagePolicy` must be satisfied for an admission, and
+having multiple `authorities` creates an `OR` clause so that any matching `authority`
+is considered a success, sometimes you may want more flexibility, for example, if you
+wanted to specify that at least 2 out of N signatures match, and for those you
+can create a single `ClusterImagePolicy` but craft a `policy` that then gets applied
+after a `ClusterImagePolicy` has been validated. Here's a bit more complex example
+that ties all the bits from above together. It requires there to be two
+attestations `custom` and `vuln` and also two signatures, one signed with a `key`
+and one `keyless` signature
+
+
+```yaml
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-requires-two-signatures-two-attestations
+spec:
+  images:
+  - glob: registry.local:5000/cosigned/demo*
+  authorities:
+  - name: keylessatt
+    keyless:
+      url: http://fulcio.fulcio-system.svc
+    ctlog:
+      url: http://rekor.rekor-system.svc
+    attestations:
+    - predicateType: custom
+      name: customkeyless
+      policy:
+        type: cue
+        data: |
+          import "time"
+          before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
+          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicate: {
+            Data: "foobar e2e test"
+            Timestamp: <before
+          }
+    - predicateType: vuln
+      name: vulnkeyless
+      policy:
+        type: cue
+        data: |
+          import "time"
+          before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
+          after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
+          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicate: {
+            invocation: {
+              uri: "invocation.example.com/cosign-testing"
+            }
+            scanner: {
+              uri: "fakescanner.example.com/cosign-testing"
+            }
+            metadata: {
+              scanStartedOn: <before
+              scanStartedOn: >after
+              scanFinishedOn: <before
+              scanFinishedOn: >after
+            }
+          }
+  - name: keyatt
+    key:
+      data: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOz9FcbJM/oOkC26Wfo9paG2tYGBL
+        usDLHze93DzgLaAPDsyJrygpVnL9M6SOyfyXEsjpBTUu6uFZqHua8hwAlA==
+        -----END PUBLIC KEY-----
+    ctlog:
+      url: http://rekor.rekor-system.svc
+    attestations:
+    - name: custom-match-predicate
+      predicateType: custom
+      policy:
+        type: cue
+        data: |
+          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicate: Data: "foobar key e2e test"
+  - name: keylesssignature
+    keyless:
+      url: http://fulcio.fulcio-system.svc
+    ctlog:
+      url: http://rekor.rekor-system.svc
+  - name: keysignature
+    key:
+      data: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOz9FcbJM/oOkC26Wfo9paG2tYGBL
+        usDLHze93DzgLaAPDsyJrygpVnL9M6SOyfyXEsjpBTUu6uFZqHua8hwAlA==
+        -----END PUBLIC KEY-----
+    ctlog:
+      url: http://rekor.rekor-system.svc
+  policy:
+    type: cue
+    data: |
+      package sigstore
+      import "struct"
+      import "list"
+      authorityMatches: {
+        keyatt: {
+          attestations: struct.MaxFields(1) & struct.MinFields(1)
+        },
+        keysignature: {
+          signatures: list.MaxItems(1) & list.MinItems(1)
+        },
+        if (len(authorityMatches.keylessatt.attestations) < 2) {
+          keylessattMinAttestations: 2
+          keylessattMinAttestations: "Error"
+        },
+        keylesssignature: {
+          signatures: list.MaxItems(1) & list.MinItems(1)
+        }
+      }
 ```
 
 ### Deprecated Cosigned Validation Behavior

--- a/content/en/cosign/kubernetes.md
+++ b/content/en/cosign/kubernetes.md
@@ -6,7 +6,7 @@ position: 102
 
 ## Kubernetes Secrets
 
-Cosign can use keys stored in Kubernetes Secrets to so sign and verify signatures.
+Cosign can use keys stored in Kubernetes Secrets to sign and verify signatures.
 In order to generate a secret you have to pass `cosign generate-key-pair` a
 `k8s://[NAMESPACE]/[NAME]` URI specifying the namespace and secret name:
 
@@ -52,7 +52,7 @@ See the [installation instructions](installation#cosigned) for more information.
 Today, `cosigned` can automatically validate signatures on container images.
 Enforcement is configured on a per-namespace basis, and multiple keys are supported.
 
-We're actively working on more features here, including support for Attestations.
+We're actively working on more features here.
 
 ### Enable Cosigned Admission Controller for Namespaces
 
@@ -139,7 +139,7 @@ spec:
 
 #### Configuring `key` Authorities
 
-When a policy is selected to be evaluated against the matched image, the authorities will be used to validate signatures.
+When a policy is selected to be evaluated against the matched image, the authorities will be used to validate signatures and attestations.
 If at least one authority is satisfied and a signature is validated, the policy is validated.
 
 **Note:** Currently, only ECDSA public keys are supported.
@@ -192,7 +192,7 @@ spec:
     - keyless:
         identities:
           - issuer: https://accounts.google.com
-            subject: *@example.com
+            subject: .*@example.com
           - issuer: https://token.actions.githubusercontent.com
             subject: https://github.com/mycompany/*/.github/workflows/*@*
 
@@ -203,7 +203,7 @@ Each `keyless` authority can contain these properties:
 - `keyless.ca-cert`: specifies `ca-cert` information for the `keyless` authority
   - `secretRef.name`: specifies the secret location name in the same namespace where `cosigned` is installed. <br/>The first key value will be used in the secret for the `ca-cert`.
   - `data`: specifies the inline certificate data
-- `keyless.identities`: Identity may contain an array of `issuer` and/or the `subject` found in the transparency log. Either field supports a pattern glob.
+- `keyless.identities`: Identity may contain an array of `issuer` and/or the `subject` found in the transparency log. Either field supports a regex.
   - `issuer`: specifies the issuer found in the transparency log. Regex patterns are supported.
   - `subject`: specifies the subject found in the transparency log. Regex patterns are supported.
 
@@ -253,9 +253,9 @@ spec:
 #### Configuring policy that validates attestations
 
 Just like with `cosign` CLI you can verify attestations (using `verify-attestation`),
-you can configure policies to validate that a particular attestation signed by
+you can configure policies to validate that a particular attestation was signed by
 a trusted authority. You do this by using `attestations` array within an `authorities`
-section. For example, to configure that a `custom` predicate has to present and
+section. For example, to configure that a `custom` predicate has to exist and is
 attested by the specified `issuer` and `subject`, and the actual `Data` section
 of the predicate matches the string `foobar e2e test`:
 


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add documentation for:
 * attestation support
 * Policy support using cue
 * ClusterImagePolicy policy support
 * Update glob matching semantics


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
 * Document attestation, policy support and CIP policy support
 * Update glob semantics with examples
```
