### PR TITLE
docs: Attach SBOMs as attestations

### DIFF
--- a/content/en/cosign/other_types.md
+++ b/content/en/cosign/other_types.md
@@ -16,10 +16,38 @@ $ crane copy alpine:latest gcr.io/$(gcloud config get-value project)/alpine:late
 $ syft packages gcr.io/$(gcloud config get-value project)/alpine:latest -o spdx > latest.spdx
 
 $ cosign attach sbom --sbom latest.spdx gcr.io/$(gcloud config get-value project)/alpine:latest # get the digest from the output
+```
 
+Note that, attaching SBOMs this way does not sign them. If you want to sign the SBOM, you can use the following command:
+
+```shell
 $ cosign sign --key cosign.key gcr.io/$(gcloud config get-value project)/alpine:sha256-e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a.sbom
 
 $ cosign verify --key cosign.pub gcr.io/$(gcloud config get-value project)/alpine:sha256-e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a.sbom
+```
+
+Or you can include the SBOM in an [in-toto](https://in-toto.io) attestation, as illustrated in the following fragment:
+
+```
+{
+  // Standard attestation fields:
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [{ ... }],
+
+  // Predicate:
+  "predicateType": "https://spdx.dev/Document",
+  "predicate": {
+    "SPDXID" : "SPDXRef-DOCUMENT",
+    "spdxVersion" : "SPDX-2.2",
+    ...
+  }
+}
+```
+
+The following command signs and attaches the attestation to the image:
+
+```shell
+$ cosign attest -predicate myattestations -key cosign.key gcr.io/$(gcloud config get-value project)/alpine:latest
 ```
 
 ## Tekton Bundles


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

As discussed in RFC #https://github.com/sigstore/cosign/issues/1742, we decided to add a note where we suggest users to include the SBOM in an attestation as a way to ensure the SBOM is tamper-proof.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #https://github.com/sigstore/cosign/issues/1742

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
docs: add note about attaching SBOMs in attestations
```
