### PR TITLE
Update Slack invite link

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -13,5 +13,5 @@ Sigstore community has a [mailing list](https://groups.google.com/g/sigstore-dev
 ## Slack
 
 Come on over to our [slack channel](https://sigstore.slack.com)!
-[Invite link](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)
+[Invite link](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -24,7 +24,7 @@ Cosign supports:
 
 <list :items="features" type="info"></list>
 
-Cosign is part of the sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)?)
+Cosign is part of the sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)?)
 
 ## Getting Started
 

--- a/content/en/fulcio/overview.md
+++ b/content/en/fulcio/overview.md
@@ -13,7 +13,7 @@ Fulcio was designed to run as a centralized, public-good instance backed up by o
 
 **Fulcio is a work in progress!** There’s working code, a running instance and a roadmap, but it’s not yet reliable or robust enough for public consumption.
 
-Fulcio is being developed as part of the sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)?)
+Fulcio is being developed as part of the sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)?)
 
 ## Usage and installation
 


### PR DESCRIPTION
#### Summary
This PR updates the invitation link to join Sigstore's Slack channel on three doc pages. Currently, the invitation links on the docs website are expired.
