### PR TITLE
Update Slack invite links on main website

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -27,7 +27,7 @@ sections:
         happening.
       ctaText: Join us on Slack
       bgColour: bg-white
-      ctaLink: https://sigstore.slack.com/join/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ#/shared-invite/email
+      ctaLink: https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg#/shared-invite/email
     column2:
       header: Share your stories
       imageAsset: /img/stories.svg

--- a/content/docs/what_is_sigstore.md
+++ b/content/docs/what_is_sigstore.md
@@ -115,7 +115,7 @@ Mostly for these reasons:
 sigstore is complementary to TUF / in-toto, and project members of the TUF / in-toto
 communities are collaborating with sigstore. For more details and the latest status
 please jump onto our [slack
-workplace](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ).
+workplace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg).
 
 ### Do you plan to run a monitor?
 
@@ -126,7 +126,7 @@ Yes, we do in some form. Currently some folks from Purdue university are working
 Yes, very much! The more people monitoring the logs and rendering or providing useful services to users, the better.
 
 We have published OpenAPI interfaces for both [Rekor](https://sigstore.dev/swagger/index.html?urls.primaryName=Rekor) and [Fulcio](https://sigstore.dev/swagger/index.html?urls.primaryName=Fulcio)
-The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)
+The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)
 to run your ideas past us.
 
 ### What is the current status of the project
@@ -138,7 +138,7 @@ WebPKI (fuclio) and develop client tools for various package managers and upstre
 ## Want to find out more?
 
 * Come on over to our [slack
-workplace](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)
+workplace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)
 * follow us on [twitter @projectsigstore](https://twitter.com/projectsigstore) (we are quite busy there with updates)
 * follow our [blog](https://blog.sigstore.dev)
 * join our mailing list at [sigstore-dev@googlegroups.com](https://groups.google.com/g/sigstore-dev)


### PR DESCRIPTION
Signed-off-by: Erika Heidi <erika@chainguard.dev>

#### Summary
This PR updates the Slack invite link on 2 different markdown pages in the main Sigstore website. 
