### PR TITLE
Updated Slack join link on community page

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -27,7 +27,7 @@ sections:
         happening.
       ctaText: Join us on Slack
       bgColour: bg-white
-      ctaLink: https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg#/shared-invite/email
+      ctaLink: https://links.sigstore.dev/slack-invite
     column2:
       header: Share your stories
       imageAsset: /img/stories.svg


### PR DESCRIPTION
#### Summary
Updates Slack join link on https://www.sigstore.dev/community using the shortlink https://links.sigstore.dev/slack-invite.

#### Release Note

```
NONE
```
