### PR TITLE
Correctly reference output flags for `cosign sign-blob`

### DIFF
--- a/content/en/cosign/working_with_blobs.md
+++ b/content/en/cosign/working_with_blobs.md
@@ -99,10 +99,10 @@ This supports all the same flags and features as `cosign sign`, including KMS su
 #### Certificate management
 
 When using `cosign sign-blob` in keyless mode, you may need to store the certificate (in addition to the signature) for verification.
-This is output to stdout by default, but can be redirected to a file with the `--cert` flag.
+This output defaults to stderr, but can be redirected to a file by using the `--output-certificate` and `--output-signature` flags.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign sign-blob  README.md
+COSIGN_EXPERIMENTAL=1 cosign sign-blob README.md --output-certificate cert.pem --output-signature sig
 Using payload from: README.md
 Generating ephemeral keys...
 Retrieving signed certificate...
@@ -129,5 +129,6 @@ PHpisPhj
 -----END CERTIFICATE-----
 
 tlog entry created with index: 965333
-MEUCIQCumPxsrw+i9ZwlWGGtX6KPPwWnd5Jpn7KWp7E+GHiHrwIgNMFmO5/N5/hmygHoG9mirxw/j+WZP3xQUlmXiDRYWKY=
+Signature wrote in the file sig
+Certificate wrote in the file cert.pem
 ```


### PR DESCRIPTION
#### Summary

The `--cert` flag does not exist (any more) while it would be good to reference how to output the signature and certificate separately.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Improved documentation about how to sign keyless blobs by mentioning the output certificate and signature flags.
```
