### PR TITLE
[docs] Adding Gitsign to the Sigstore documentation

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -16,7 +16,7 @@ Docs and other calendar invites may be shared directly with this group, so pleas
 ## Slack
 
 You can also keep in touch by joining our [Slack channel](https://sigstore.slack.com). Use 
-[this invite link](https://links.sigstore.dev/slack) to join.
+[this invite link](https://links.sigstore.dev/slack-invite) to join.
 
 [//]: # (In case the invite link is expired, ping Dan on Slack of via Twitter: @lorenc_dan)
 

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -15,8 +15,7 @@ Docs and other calendar invites may be shared directly with this group, so pleas
 
 ## Slack
 
-You can also keep in touch by joining our [Slack channel](https://sigstore.slack.com). Use 
-[this invite link](https://links.sigstore.dev/slack-invite) to join.
+You can also keep in touch by joining our [Slack channel](https://sigstore.slack.com). Use [this invite link](https://links.sigstore.dev/slack-invite) to join.
 
 [//]: # (In case the invite link is expired, ping Dan on Slack of via Twitter: @lorenc_dan)
 

--- a/content/en/gitsign/FAQ.md
+++ b/content/en/gitsign/FAQ.md
@@ -1,0 +1,64 @@
+---
+title: "Gitsign FAQ"
+menuTitle: "FAQ"
+category: "Gitsign"
+position: 155
+---
+
+## Why using Gitsign instead of the usual commit signing workflow?
+A typical commit signing workflow requires developers to create special signing keys that must be safely stored in the system that will sign the commits. 
+
+In addition to that, verifying signatures require access to the signer's public key. Distributing public keys while also attesting they truly belong to a certain identity can be very challenging. 
+That's where [keyless signing with Cosign](/cosign/openid_signing) comes in handy, allowing developers to use their OpenID identities to sign commits and improve the overall trust of an open source project.
+
+## Why does the authentication workflow requires opening a browser window? 
+
+When Git invokes signing tools, both stdout and stderr are captured which means `gitsign` cannot push back messages to shells interactively. Because of this, device mode does not work with `gitsign` - a browser capable session is required to sign commits. 
+
+## I signed my commit with Gitsign, but it shows up as "unverified" in my GitHub repository page. Why?
+
+![Unverified signed commit](https://github.com/sigstore/gitsign/raw/main/images/unverified.png)
+
+At the moment, GitHub doesn't recognize Gitsign signatures as `verified` for two reasons:
+
+1. The Sigstore CA root is not a part of [GitHub's trust root](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#smime-commit-signature-verification).
+2. Because Gitsign's ephemeral keys are only valid for a short time, using standard x509 verification would consider the certificate invalid after expiration. Verification needs to include validation via [Rekor](/rekor/overview) to verify
+   that the certificate was valid at the time it was used.
+
+We hope to work closely with GitHub to get these types of signatures recognized as verified in the near future.
+
+You can find more information about GitHub's commit signature verification in their [official docs](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
+## What data does Gitsign store?
+
+Gitsign stores data in 2 places:
+
+### 1. Within the Git commit
+
+   The commit itself contains a signed digest of the user commit content (e.g.
+   author, committer, message, etc.) along with the code signing
+   certificate. This data is stored within the commit itself as part of your
+   repository. See
+   [Inspecting the Git commit signature](#inspecting-the-git-commit-signature)
+   for more details.
+
+### 2. Within the Rekor transparency log
+
+   To be able to verify signatures for ephemeral certs past their `Not After`
+   time, gitsign records commits and the code signing certificates to
+   [Rekor](https://docs.sigstore.dev/rekor/overview/). This data is a
+   [HashedRekord](https://github.com/sigstore/rekor/blob/e375eb461cae524270889b57a249ff086bea6c05/types.md#hashed-rekord)
+   containing a SHA256 hash of the commit SHA, as well as the code signing
+   certificate. See
+   [Verifying the Transparency Log](#verifying-the-transparency-log) for more
+   details.
+
+   By default, data is written to the
+   [public Rekor instance](https://docs.sigstore.dev/rekor/public-instance). In
+   particular, users and organizations may be sensitive to the data contained
+   within code signing certificatesm returned by Fulcio, which may include user
+   emails or repository identifiers. See
+   [OIDC usage in Fulcio](https://github.com/sigstore/fulcio/blob/6ac6b8c94c3ec6106d68c0f92225016a3a6eef79/docs/oidc.md)
+   for more details for what data is contained in the code signing certs, and
+   [Deploy a Rekor Server Manually](https://docs.sigstore.dev/rekor/installation/#deploy-a-rekor-server-manually)
+   for how to run your own Rekor instance.

--- a/content/en/gitsign/installation.md
+++ b/content/en/gitsign/installation.md
@@ -1,0 +1,93 @@
+---
+title: "Gitsign Installation"
+menuTitle: "Installation"
+category: "Gitsign"
+position: 152
+---
+
+## Installing Gitsign
+
+You can install Gitsign on your system either via the Go installer or with one of the available downloadable packages.
+Releases are published in [the Gitsign repository](https://github.com/sigstore/gitsign) under the [Releases page](https://github.com/sigstore/gitsign/releases).
+
+### Installing Gitsign with Go 1.17+
+
+If you have Go 1.17+, you can install Gitsign with:
+
+```console
+go install github.com/sigstore/gitsign@latest
+```
+
+The resulting binary will be placed at `$GOPATH/bin/gitsign`. 
+
+### Installing Gitsign with the `.deb` package (Debian / Ubuntu Linux)
+
+Check the [releases page](https://github.com/sigstore/cosign/releases) for the latest release, and download the appropriate `.deb` file.
+
+```console
+wget https://github.com/sigstore/gitsign/releases/download/v0.1.0/gitsign_0.1.0_linux_amd64.deb
+sudo dpkg -i gitsign_0.1.0_linux_amd64.deb
+```
+
+### Installing Gitsign with the `.rpm` package (Fedora Linux)
+
+Check the [releases page](https://github.com/sigstore/cosign/releases) for the latest release, and download the appropriate `.rpm` file. 
+
+```console
+wget https://github.com/sigstore/gitsign/releases/download/v0.1.0/gitsign_0.1.0_linux_amd64.rpm
+rpm -ivh gitsign_0.1.0_linux_amd64.rpm
+```
+
+## Checking your installation
+
+Once you finish installing Gitsign, you can test that it is functional and can be found on your $PATH with:
+
+```shell
+gitsign --help
+```
+```console
+Usage: gitsign [-abhsv] [--include-certs n] [--status-fd n] [-t url] [-u USER-ID] [--verify] [files]
+ -a, --armor                    create ascii armored output
+ -b, --detach-sign              make a detached signature
+ -h, --help                     print this help message
+     --include-certs=n          -3 is the same as -2, but ommits issuer
+                                when cert has Authority Information
+                                Access extension. -2 includes all certs
+                                except root. -1 includes all certs. 0
+                                includes no certs. 1 includes leaf cert.
+                                >1 includes n from the leaf. Default -2.
+ -s, --sign                     make a signature
+     --status-fd=n              write special status strings to the file
+                                descriptor n.
+ -t, --timestamp-authority=url  URL of RFC3161 timestamp authority to
+                                use for timestamping
+ -u, --local-user=USER-ID       use USER-ID to sign
+     --verify                   verify a signature
+ -v, --version                  print the version number
+```
+
+### Troubleshooting 
+
+If you get an error such as `command not found`, it may be the case that your $PATH does not include the relevant bin directories where Gitsign should be installed. 
+If you installed Gitsign with Go, make sure you have your Go bin directory added to your $PATH.
+
+## Configuring Git to use Gitsign
+
+After installing Gitsign on your system and making sure it is functional, you'll need to tell Git that you want to use Gitsign to sign your commits from now on, whether locally on a project-based configuration or globally, which will be valid for commits made from this system to any project.
+
+### Single Repository (local config):
+
+```sh
+cd /path/to/my/repository
+git config --local commit.gpgsign true  # Sign all commits
+git config --local gpg.x509.program gitsign  # Use gitsign for signing
+git config --local gpg.format x509  # gitsign expects x509 args
+```
+
+### All repositories (global config):
+
+```sh
+git config --global commit.gpgsign true  # Sign all commits
+git config --global gpg.x509.program gitsign  # Use gitsign for signing
+git config --global gpg.format x509  # gitsign expects x509 args
+```

--- a/content/en/gitsign/overview.md
+++ b/content/en/gitsign/overview.md
@@ -1,0 +1,56 @@
+---
+title: "Gitsign Overview"
+menuTitle: "Overview"
+category: "Gitsign"
+position: 150
+---
+
+<img src="/sigstore_overview_v1.jpg" class="light-img" width="1280" height="640" alt=""/>
+
+Gitsign implements keyless Sigstore to sign Git commits with a valid [OpenID](https://openid.net/connect/) identity.
+In practice, that means you won't need to deal with gpg keys and a complicated setup in order to sign your Git commits. After installing and configuring Gitsign within your project, when signing your commits you will be redirected to a browser window to authenticate with a supported OpenID provider, such as GitHub or Google.
+Signing details will then be stored in [Rekor](/rekor/overview) for posterior consultation.
+
+Gitsign is part of the Sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) if you want to learn more or get involved. Need an [invite](https://links.sigstore.dev/slack-invite)?
+
+[//]: # (In case the invite link is expired, ping Dan on Slack or via Twitter: @lorenc_dan)
+
+## Quick Start
+
+Gitsign can be installed via the Go installer or with one of the package installers available on the project's [releases page](https://github.com/sigstore/gitsign/releases). These include  `.deb` and `.rpm` formats for Debian and Fedora systems respectively. Check the [installation](/gitsign/installation) page for more details on how to get Gitsign installed on your system.
+
+Once configured, you can sign commits as usual with `git commit -s`:
+
+```sh
+$ git commit -s --allow-empty --message="Signed commit"
+[main cb6eee1] Signed commit
+```
+
+This will redirect you through the [Sigstore Keyless flow](/cosign/openid_signing) to authenticate and
+sign the commit.
+
+Commits can then be verified using `git log`:
+
+```sh
+$ git --no-pager log --show-signature -1
+commit 227e796042fdd170e58b7e3b7627a1badd320224 (HEAD -> main)
+searching tlog for commit: 227e796042fdd170e58b7e3b7627a1badd320224
+tlog index: 2212633
+smimesign: Signature made using certificate ID 0x815ada5516906a862af8f528d69d3c86e4774b4f | CN=sigstore,O=sigstore.dev
+smimesign: Good signature from "" ([billy@chainguard.dev])
+Author: Billy Lynch <billy@chainguard.dev>
+Date:   Mon May 2 16:51:44 2022 -0400
+
+    Signed commit
+```
+
+## Environment Variables
+
+| Environment Variable      | Default                          | Description                                                                                                   |
+| ------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| GITSIGN_FULCIO_URL        | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                      |
+| GITSIGN_LOG               |                                  | Path to log status output. Helpful for debugging, since Git will not forward stderr output to user terminals. |
+| GITSIGN_OIDC_CLIENT_ID    | sigstore                         | OIDC client ID for application                                                                                |
+| GITSIGN_OIDC_ISSUER       | https://oauth2.sigstore.dev/auth | OIDC provider to be used to issue ID token                                                                    |
+| GITSIGN_OIDC_REDIRECT_URL |                                  | OIDC Redirect URL                                                                                             |
+| GITSIGN_REKOR_URL         | https://rekor.sigstore.dev       | Address of Rekor server                                                                                       |

--- a/content/en/gitsign/usage.md
+++ b/content/en/gitsign/usage.md
@@ -1,0 +1,342 @@
+---
+title: "Detailed Gitsign Usage"
+menuTitle: "Usage"
+category: "Gitsign"
+position: 153
+---
+
+## Signing a commit
+After installing Gitsign and [configuring Git to use it as signer application](/gitsign/installation#configuring-git-to-use-gitsign-for-signing) for your project (or globally), you can sign commits as usual with `git commit -s` :
+
+```console
+$ git commit -s --allow-empty --message="Signed commit"
+[main cb6eee1] Signed commit
+```
+
+This will redirect you through the Sigstore Keyless flow to authenticate and
+sign the commit.
+
+Commits can then be verified using `git log`:
+
+```sh
+$ git --no-pager log --show-signature -1
+commit 227e796042fdd170e58b7e3b7627a1badd320224 (HEAD -> main)
+searching tlog for commit: 227e796042fdd170e58b7e3b7627a1badd320224
+tlog index: 2212633
+smimesign: Signature made using certificate ID 0x815ada5516906a862af8f528d69d3c86e4774b4f | CN=sigstore,O=sigstore.dev
+smimesign: Good signature from "" ([billy@chainguard.dev])
+Author: Billy Lynch <billy@chainguard.dev>
+Date:   Mon May 2 16:51:44 2022 -0400
+
+    Signed commit
+```
+
+## Inspecting the Git commit signature
+
+Git commit signatures use
+[CMS/PKCS7 signatures](https://datatracker.ietf.org/doc/html/rfc5652). We can
+inspect the underlying data / certificate used by running:
+
+```sh
+$ git cat-file commit HEAD | sed -n '/BEGIN/, /END/p' | sed 's/^ //g' | sed 's/gpgsig //g' | sed 's/SIGNED MESSAGE/PKCS7/g' | openssl pkcs7 -print -print_certs -text
+PKCS7:
+  type: pkcs7-signedData (1.2.840.113549.1.7.2)
+  d.sign:
+    version: 1
+    md_algs:
+        algorithm: sha256 (2.16.840.1.101.3.4.2.1)
+        parameter: <ABSENT>
+    contents:
+      type: pkcs7-data (1.2.840.113549.1.7.1)
+      d.data: <ABSENT>
+    cert:
+        cert_info:
+          version: 2
+          serialNumber: 4061203728062639434060493046878247211328523247
+          signature:
+            algorithm: ecdsa-with-SHA384 (1.2.840.10045.4.3.3)
+            parameter: <ABSENT>
+          issuer: O=sigstore.dev, CN=sigstore
+          validity:
+            notBefore: May  2 20:51:47 2022 GMT
+            notAfter: May  2 21:01:46 2022 GMT
+          subject:
+          key:
+            algor:
+              algorithm: id-ecPublicKey (1.2.840.10045.2.1)
+              parameter: OBJECT:prime256v1 (1.2.840.10045.3.1.7)
+            public_key:  (0 unused bits)
+              0000 - 04 ec 60 4b 67 aa 28 d9-34 f3 83 9c 17 a5   ..`Kg.(.4.....
+              000e - c8 a5 87 5e de db c2 65-c8 8b e6 dc c4 6f   ...^...e.....o
+              001c - 9c 87 60 05 42 18 f7 b7-0d 8f 06 f1 62 ce   ..`.B.......b.
+              002a - 9a 59 9d 71 12 55 1b c3-d4 c7 90 a5 f6 0a   .Y.q.U........
+              0038 - b4 1a b3 0e a7 3d 4e 12-38                  .....=N.8
+          issuerUID: <ABSENT>
+          subjectUID: <ABSENT>
+          extensions:
+              object: X509v3 Key Usage (2.5.29.15)
+              critical: TRUE
+              value:
+                0000 - 03 02 07 80                              ....
+
+              object: X509v3 Extended Key Usage (2.5.29.37)
+              critical: BOOL ABSENT
+              value:
+                0000 - 30 0a 06 08 2b 06 01 05-05 07 03 03      0...+.......
+
+              object: X509v3 Basic Constraints (2.5.29.19)
+              critical: TRUE
+              value:
+                0000 - 30                                       0
+                0002 - <SPACES/NULS>
+
+              object: X509v3 Subject Key Identifier (2.5.29.14)
+              critical: BOOL ABSENT
+              value:
+                0000 - 04 14 a0 b1 ea 03 c5 08-4a 70 93 21 da   ........Jp.!.
+                000d - a3 a0 0b 4c 55 49 d3 06-3d               ...LUI..=
+
+              object: X509v3 Authority Key Identifier (2.5.29.35)
+              critical: BOOL ABSENT
+              value:
+                0000 - 30 16 80 14 58 c0 1e 5f-91 45 a5 66 a9   0...X.._.E.f.
+                000d - 7a cc 90 a1 93 22 d0 2a-c5 c5 fa         z....".*...
+
+              object: X509v3 Subject Alternative Name (2.5.29.17)
+              critical: TRUE
+              value:
+                0000 - 30 16 81 14 62 69 6c 6c-79 40 63 68 61   0...billy@cha
+                000d - 69 6e 67 75 61 72 64 2e-64 65 76         inguard.dev
+
+              object: undefined (1.3.6.1.4.1.57264.1.1)
+              critical: BOOL ABSENT
+              value:
+                0000 - 68 74 74 70 73 3a 2f 2f-67 69 74 68 75   https://githu
+                000d - 62 2e 63 6f 6d 2f 6c 6f-67 69 6e 2f 6f   b.com/login/o
+                001a - 61 75 74 68                              auth
+        sig_alg:
+          algorithm: ecdsa-with-SHA384 (1.2.840.10045.4.3.3)
+          parameter: <ABSENT>
+        signature:  (0 unused bits)
+          0000 - 30 65 02 31 00 af be f5-bf e7 05 f5 15 e2 07   0e.1...........
+          000f - 85 48 00 ce 81 1e 3e ba-7b 21 d3 e4 a4 8a e6   .H....>.{!.....
+          001e - e5 38 9f 01 8a 16 6c 4c-d3 94 af 77 f0 7d 6e   .8....lL...w.}n
+          002d - b1 9c f9 29 f9 2c b5 13-02 30 74 eb a5 5a 8a   ...).,...0t..Z.
+          003c - 77 a0 95 7f 42 8e df 6a-ed 26 96 cc b4 30 29   w...B..j.&...0)
+          004b - b7 94 18 32 c6 8d a5 a4-06 88 e2 01 51 c4 61   ...2........Q.a
+          005a - 36 1a 1a 55 ec df a4 0a-84 b5 03 6e 12         6..U.......n.
+    crl:
+      <EMPTY>
+    signer_info:
+        version: 1
+        issuer_and_serial:
+          issuer: O=sigstore.dev, CN=sigstore
+          serial: 4061203728062639434060493046878247211328523247
+        digest_alg:
+          algorithm: sha256 (2.16.840.1.101.3.4.2.1)
+          parameter: <ABSENT>
+        auth_attr:
+            object: contentType (1.2.840.113549.1.9.3)
+            value.set:
+              OBJECT:pkcs7-data (1.2.840.113549.1.7.1)
+
+            object: signingTime (1.2.840.113549.1.9.5)
+            value.set:
+              UTCTIME:May  2 20:51:49 2022 GMT
+
+            object: messageDigest (1.2.840.113549.1.9.4)
+            value.set:
+              OCTET STRING:
+                0000 - 66 4e 98 f6 29 46 31 f6-ca 8f 21 44 06   fN..)F1...!D.
+                000d - 34 07 2a 8a b2 dd 64 29-4a e9 74 71 d0   4.*...d)J.tq.
+                001a - a1 84 ec d5 03 3f                        .....?
+        digest_enc_alg:
+          algorithm: ecdsa-with-SHA256 (1.2.840.10045.4.3.2)
+          parameter: <ABSENT>
+        enc_digest:
+          0000 - 30 45 02 20 58 02 c6 8c-30 51 df 4b 14 5e ff   0E. X...0Q.K.^.
+          000f - 54 a8 b3 44 0e 32 25 3a-2d 5b cf d9 e4 4e 4c   T..D.2%:-[...NL
+          001e - 37 47 af 6e d4 17 02 21-00 81 d9 4c fc b7 e3   7G.n...!...L...
+          002d - 92 7e cd a7 c8 84 d6 ae-47 93 88 bd 17 c2 92   .~......G......
+          003c - a3 d4 a3 00 ec f6 c9 5b-8b 81 9a               .......[...
+        unauth_attr:
+          <EMPTY>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            b6:1c:55:19:85:4a:99:bd:57:12:0d:ec:75:bb:9a:1a:4e:cb:ef
+    Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=sigstore.dev, CN=sigstore
+        Validity
+            Not Before: May  2 20:51:47 2022 GMT
+            Not After : May  2 21:01:46 2022 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:ec:60:4b:67:aa:28:d9:34:f3:83:9c:17:a5:c8:
+                    a5:87:5e:de:db:c2:65:c8:8b:e6:dc:c4:6f:9c:87:
+                    60:05:42:18:f7:b7:0d:8f:06:f1:62:ce:9a:59:9d:
+                    71:12:55:1b:c3:d4:c7:90:a5:f6:0a:b4:1a:b3:0e:
+                    a7:3d:4e:12:38
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage:
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                A0:B1:EA:03:C5:08:4A:70:93:21:DA:A3:A0:0B:4C:55:49:D3:06:3D
+            X509v3 Authority Key Identifier:
+                keyid:58:C0:1E:5F:91:45:A5:66:A9:7A:CC:90:A1:93:22:D0:2A:C5:C5:FA
+
+            X509v3 Subject Alternative Name: critical
+                email:billy@chainguard.dev
+            1.3.6.1.4.1.57264.1.1:
+                https://github.com/login/oauth
+    Signature Algorithm: ecdsa-with-SHA384
+         30:65:02:31:00:af:be:f5:bf:e7:05:f5:15:e2:07:85:48:00:
+         ce:81:1e:3e:ba:7b:21:d3:e4:a4:8a:e6:e5:38:9f:01:8a:16:
+         6c:4c:d3:94:af:77:f0:7d:6e:b1:9c:f9:29:f9:2c:b5:13:02:
+         30:74:eb:a5:5a:8a:77:a0:95:7f:42:8e:df:6a:ed:26:96:cc:
+         b4:30:29:b7:94:18:32:c6:8d:a5:a4:06:88:e2:01:51:c4:61:
+         36:1a:1a:55:ec:df:a4:0a:84:b5:03:6e:12
+-----BEGIN CERTIFICATE-----
+MIICFTCCAZugAwIBAgIUALYcVRmFSpm9VxIN7HW7mhpOy+8wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA1MDIyMDUxNDdaFw0yMjA1MDIyMTAxNDZaMAAwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATsYEtnqijZNPODnBelyKWHXt7bwmXIi+bcxG+ch2AFQhj3tw2PBvFi
+zppZnXESVRvD1MeQpfYKtBqzDqc9ThI4o4HIMIHFMA4GA1UdDwEB/wQEAwIHgDAT
+BgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBSgseoD
+xQhKcJMh2qOgC0xVSdMGPTAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF
++jAiBgNVHREBAf8EGDAWgRRiaWxseUBjaGFpbmd1YXJkLmRldjAsBgorBgEEAYO/
+MAEBBB5odHRwczovL2dpdGh1Yi5jb20vbG9naW4vb2F1dGgwCgYIKoZIzj0EAwMD
+aAAwZQIxAK++9b/nBfUV4geFSADOgR4+unsh0+SkiublOJ8BihZsTNOUr3fwfW6x
+nPkp+Sy1EwIwdOulWop3oJV/Qo7fau0mlsy0MCm3lBgyxo2lpAaI4gFRxGE2GhpV
+7N+kCoS1A24S
+-----END CERTIFICATE-----
+```
+
+### Verifying the Transparency Log
+
+As part of signature verification, `gitsign` not only checks that the given
+signature matches the commit, but also that the commit exists within the Rekor
+transparency log.
+
+We can manually validate that the commit exists in the transparency log by
+running:
+
+```sh
+$ uuid=$(rekor-cli search --artifact <(git rev-parse HEAD | tr -d '\n') | tail -n 1)
+$ rekor-cli get --uuid=$uuid --format=json | jq .
+LogID: c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d
+Index: 2212633
+IntegratedTime: 2022-05-02T20:51:49Z
+UUID: d0444ed9897f31fefc820ade9a706188a3bb030055421c91e64475a8c955ae2c
+Body: {
+  "HashedRekordObj": {
+    "data": {
+      "hash": {
+        "algorithm": "sha256",
+        "value": "05b4f02a24d1c4c2c95dacaee30de2a6ce4b5b88fa981f4e7b456b76ea103141"
+      }
+    },
+    "signature": {
+      "content": "MEYCIQCeZwhnq9dgS7ZvU2K5m785V6PqqWAsmkNzAOsf8F++gAIhAKfW2qReBZL34Xrzd7r4JzUlJbf5eoeUZvKT+qsbbskL",
+      "publicKey": {
+        "content": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNGVENDQVp1Z0F3SUJBZ0lVQUxZY1ZSbUZTcG05VnhJTjdIVzdtaHBPeSs4d0NnWUlLb1pJemowRUF3TXcKS2pFVk1CTUdBMVVFQ2hNTWMybG5jM1J2Y21VdVpHVjJNUkV3RHdZRFZRUURFd2h6YVdkemRHOXlaVEFlRncweQpNakExTURJeU1EVXhORGRhRncweU1qQTFNREl5TVRBeE5EWmFNQUF3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPClBRTUJCd05DQUFUc1lFdG5xaWpaTlBPRG5CZWx5S1dIWHQ3YndtWElpK2JjeEcrY2gyQUZRaGozdHcyUEJ2RmkKenBwWm5YRVNWUnZEMU1lUXBmWUt0QnF6RHFjOVRoSTRvNEhJTUlIRk1BNEdBMVVkRHdFQi93UUVBd0lIZ0RBVApCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBekFNQmdOVkhSTUJBZjhFQWpBQU1CMEdBMVVkRGdRV0JCU2dzZW9ECnhRaEtjSk1oMnFPZ0MweFZTZE1HUFRBZkJnTlZIU01FR0RBV2dCUll3QjVma1VXbFpxbDZ6SkNoa3lMUUtzWEYKK2pBaUJnTlZIUkVCQWY4RUdEQVdnUlJpYVd4c2VVQmphR0ZwYm1kMVlYSmtMbVJsZGpBc0Jnb3JCZ0VFQVlPLwpNQUVCQkI1b2RIUndjem92TDJkcGRHaDFZaTVqYjIwdmJHOW5hVzR2YjJGMWRHZ3dDZ1lJS29aSXpqMEVBd01ECmFBQXdaUUl4QUsrKzliL25CZlVWNGdlRlNBRE9nUjQrdW5zaDArU2tpdWJsT0o4QmloWnNUTk9VcjNmd2ZXNngKblBrcCtTeTFFd0l3ZE91bFdvcDNvSlYvUW83ZmF1MG1sc3kwTUNtM2xCZ3l4bzJscEFhSTRnRlJ4R0UyR2hwVgo3TitrQ29TMUEyNFMKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+      }
+    }
+  }
+}
+
+$ sig=$(rekor-cli get --uuid=$uuid --format=json | jq -r .Body.HashedRekordObj.signature.content)
+$ cert=$(rekor-cli get --uuid=$uuid --format=json | jq -r .Body.HashedRekordObj.signature.publicKey.content)
+$ cosign verify-blob --cert <(echo $cert | base64 --decode) --signature <(echo $sig | base64 --decode) <(git rev-parse HEAD | tr -d '\n')
+tlog entry verified with uuid: d0444ed9897f31fefc820ade9a706188a3bb030055421c91e64475a8c955ae2c index: 2212633
+Verified OK
+$ echo $cert | base64 --decode | openssl x509 -text
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            b6:1c:55:19:85:4a:99:bd:57:12:0d:ec:75:bb:9a:1a:4e:cb:ef
+    Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=sigstore.dev, CN=sigstore
+        Validity
+            Not Before: May  2 20:51:47 2022 GMT
+            Not After : May  2 21:01:46 2022 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:ec:60:4b:67:aa:28:d9:34:f3:83:9c:17:a5:c8:
+                    a5:87:5e:de:db:c2:65:c8:8b:e6:dc:c4:6f:9c:87:
+                    60:05:42:18:f7:b7:0d:8f:06:f1:62:ce:9a:59:9d:
+                    71:12:55:1b:c3:d4:c7:90:a5:f6:0a:b4:1a:b3:0e:
+                    a7:3d:4e:12:38
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage:
+                Code Signing
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                A0:B1:EA:03:C5:08:4A:70:93:21:DA:A3:A0:0B:4C:55:49:D3:06:3D
+            X509v3 Authority Key Identifier:
+                keyid:58:C0:1E:5F:91:45:A5:66:A9:7A:CC:90:A1:93:22:D0:2A:C5:C5:FA
+
+            X509v3 Subject Alternative Name: critical
+                email:billy@chainguard.dev
+            1.3.6.1.4.1.57264.1.1:
+                https://github.com/login/oauth
+    Signature Algorithm: ecdsa-with-SHA384
+         30:65:02:31:00:af:be:f5:bf:e7:05:f5:15:e2:07:85:48:00:
+         ce:81:1e:3e:ba:7b:21:d3:e4:a4:8a:e6:e5:38:9f:01:8a:16:
+         6c:4c:d3:94:af:77:f0:7d:6e:b1:9c:f9:29:f9:2c:b5:13:02:
+         30:74:eb:a5:5a:8a:77:a0:95:7f:42:8e:df:6a:ed:26:96:cc:
+         b4:30:29:b7:94:18:32:c6:8d:a5:a4:06:88:e2:01:51:c4:61:
+         36:1a:1a:55:ec:df:a4:0a:84:b5:03:6e:12
+-----BEGIN CERTIFICATE-----
+MIICFTCCAZugAwIBAgIUALYcVRmFSpm9VxIN7HW7mhpOy+8wCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA1MDIyMDUxNDdaFw0yMjA1MDIyMTAxNDZaMAAwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATsYEtnqijZNPODnBelyKWHXt7bwmXIi+bcxG+ch2AFQhj3tw2PBvFi
+zppZnXESVRvD1MeQpfYKtBqzDqc9ThI4o4HIMIHFMA4GA1UdDwEB/wQEAwIHgDAT
+BgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBSgseoD
+xQhKcJMh2qOgC0xVSdMGPTAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF
++jAiBgNVHREBAf8EGDAWgRRiaWxseUBjaGFpbmd1YXJkLmRldjAsBgorBgEEAYO/
+MAEBBB5odHRwczovL2dpdGh1Yi5jb20vbG9naW4vb2F1dGgwCgYIKoZIzj0EAwMD
+aAAwZQIxAK++9b/nBfUV4geFSADOgR4+unsh0+SkiublOJ8BihZsTNOUr3fwfW6x
+nPkp+Sy1EwIwdOulWop3oJV/Qo7fau0mlsy0MCm3lBgyxo2lpAaI4gFRxGE2GhpV
+7N+kCoS1A24S
+-----END CERTIFICATE-----
+```
+
+Notice that **the Rekor entry uses the same cert that was used to generate the
+git commit signature**. This can be used to correlate the 2 messages, even
+though they signed different content!
+
+## Debugging
+
+If there is a problem during signing, you may see an error like the following:
+
+```
+error: gpg failed to sign the data
+fatal: failed to write commit object
+```
+
+Because of Limitations with Git signing tools, `gitsign`
+cannot write back to stderr. Instead, you can use the `GITSIGN_LOG` environment
+variable to tee logs into a readable location for debugging.
+
+


### PR DESCRIPTION
#### Summary
This PR introduces a new section for Gitsign in the Sigstore documentation website. The content was based on the current Gitsign README and a few other details I obtained while trying it out.

The menu positioning was chosen so that it stays closer to Cosign, I thought that would make more sense. 

TODO: needs a custom header image for the overview page. Currently reusing a more generic Sigstore image as a placeholder.

#### Release Note
```release-note
Added new section for Gitsign in the Sigstore docs website.
```
