### PR TITLE
Fix link to full KMS docs

### DIFF
--- a/content/en/cosign/usage.md
+++ b/content/en/cosign/usage.md
@@ -258,7 +258,7 @@ When referring to a key managed by a KMS provider, `cosign` takes a [go-cloud](h
 
 For example: `gcpkms://`, `awskms://`, or `hashivault://`
 
-To see the full set of KMS APIs supported, and options for each, see [the KMS docs](kms_support).
+To see the full set of KMS APIs supported, and options for each, see [the KMS docs](../kms_support).
 
 The URI path syntax is provider specific and explained in the section for each provider.
 


### PR DESCRIPTION
Before this change, the link here: https://docs.sigstore.dev/cosign/usage/#kms-usage would go to https://docs.sigstore.dev/cosign/usage/kms_support, which 404s.

Notably, if you click the link from https://docs.sigstore.dev/cosign/usage/#kms-usage (note the lack of trailing `/`), the link works.

I believe this form should consistently work regardless of trailing `/`.

Signed-off-by: Jason Hall <imjasonh@gmail.com>


#### Release Note
```release-note
NONE
```
