### PR TITLE
Fix documentation bug: tlog to ctlog

### DIFF
--- a/content/en/policy-controller/overview.md
+++ b/content/en/policy-controller/overview.md
@@ -242,18 +242,19 @@ spec:
 
 **Note:** The secret has to be in the format `type: dockerconfigjson`.
 
-#### Configuring Transparency Log
+#### Configuring Certificate Transparency Log
 
-TLog specifies the URL to a transparency log that holds signature and public key information.
+CTLog specifies the URL to a certificate transparency log that holds signature
+and public key information.
 
-When `tlog` key is not specified, the public rekor instance will be used.
+When `ctlog` key is not specified, the public rekor instance will be used.
 
 ```yaml
 spec:
   authorities:
     - keyless:
         url: https://fulcio.example.com
-      tlog:
+      ctlog:
         url: https://rekor.example.com
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix incorrect field name in example. It was correct in most places, but here it was wrong, so fixed.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->