### PR TITLE
Fix edit this page link

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -8,6 +8,6 @@
     "light": "/logo-light.svg",
     "dark": "/logo-dark.svg"
   },
-  "github": "sigstore/sigstore-website/tree/docs",
+  "github": "sigstore/sigstore-website",
   "twitter": "@projectsigstore"
 }


### PR DESCRIPTION
Signed-off-by: Lisa <lisa.tagliaferri@gmail.com>

#### Summary

Resolves #101 — "Edit this page on GitHub" links were broken, this is a fix to update this. 

![Recording 2022-07-08 at 13 46 58](https://user-images.githubusercontent.com/5977693/178043953-0b690ac3-53a2-4d38-b433-725352c86c60.gif)

#### Release Note

* Bug fixes and fixes of previous known issues

URL update to `content/settings.json` to address known bug

#### Documentation

This is a bug fix, but the workflow of clicking the link to edit a page should be documented on the contributors' guide.

