### PR TITLE
Update homepage numbers

### DIFF
--- a/content/setup/info.json
+++ b/content/setup/info.json
@@ -1,7 +1,7 @@
 {
-  "commits": 675,
-  "members": 465,
+  "commits": 2800,
+  "members": 1200,
   "organizations": 20,
   "sitename": "Sigstore",
-  "sitedescription": "Sigstore description"
+  "sitedescription": "A new standard for signing, verifying and protecting software"
 }


### PR DESCRIPTION
Signed-off-by: Lisa <lisa.tagliaferri@gmail.com>

#### Summary
Resolves #37 comment on the community-based numbers on the homepage.

<img width="1064" alt="Screen Shot 2022-07-10 at 5 13 59 PM" src="https://user-images.githubusercontent.com/5977693/178162303-77243cfb-ac93-49bc-aeb6-b24e42b84c23.png">

I think this is good to merge but we may want to change breaking points or more padding for the user experience and responsiveness of the view. 

#### Release Note
This is an update to reflect the growth of the project and keep it maintained. 

#### Documentation
Not needed.