### PR TITLE
Add history / research page, practical links to the overview page

### DIFF
--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -13,12 +13,12 @@ features:
   - Rego and Cuelang integrations for policy definition
 ---
 
-<img src="/cosign_overview_v1.jpg" class="light-img" width="1280" height="640" alt=""/>
+![Cosign Overview](/cosign_overview_v1.jpg)
 
 Cosign supports container signing, verification, and storage in an OCI registry.
 Cosign aims to make signatures invisible infrastructure.
 
-<img src="/cosign.gif" class="light-img" width="1280" height="640" alt=""/>
+![Cosign demo gif](/cosign.gif)
 
 Cosign supports:
 

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -1,0 +1,43 @@
+---
+title: 'History and Research'
+description: ''
+category: 'About sigstore'
+position: 4
+---
+
+_An earlier version of some of this material was published in Chapter 5 of the [Linux Foundation Sigstore course](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home)._
+
+Since its founding, over 100 contributors pushed over 2,800 commits to the Sigstore open-source repository. These contributors hail from 20 different organizations, including Google, Red Hat, Chainguard, Purdue University, VMware, Twitter, Citi, Charm, Anchor, and Iron Bank. As an open-source project that is growing in popularity, Sigstore currently has over 2,000 GitHub Stars and the project has over 2.25 million log entries. Today, there are over 1,100 active members on the public Slack channel, and many who regularly attend the weekly Sigstore community meetings.
+
+## A Short History Leading to Sigstore
+
+In response to a man-in-the-middle attack through a misissued wildcard HTTPS certificate for google.com, Ben Laurie wrote on Google’s approach to mitigate this issue going forward through certificate transparency. In 2014, he published “[Certificate Transparency](https://certificate.transparency.dev/)” in ACM’s _Queue_ about the approach, which was in active development. With certificate transparency, certificates could be public and verifiable through append-only logs. Out of this work came the [Certificate Transparency](Certificate Transparency) project — an ecosystem to support making website certificate issuance more transparent and verifiable.  
+
+In 2015, the [Verifiable Data Structures](https://github.com/google/trillian/blob/master/docs/papers/VerifiableDataStructures.pdf) white paper was written by a team at Google (Adam Eijdenberg, Ben Laurie, and Al Cutter). This effort extended and generalized the ideas put forth by Laurie in his Certificate Transparency paper of 2014. The white paper discusses Verifiable Logs, Verifiable Maps, and Verifiable Log Backed Maps as data structures and provides the example of a Verifiable Database that leverages a Verifiable Log and a Verifiable Map. The Trillian project is an implementation of the ideas put forth in this white paper. 
+
+A transparent, scalable, and cryptographically verifiable data store, [Trillian](https://trillian.im/) implements a Merkle tree and can therefore cryptographically prove that a given record is in the log and also that the log has not been tampered with. A tampered log would be changed or have something deleted since a previous point in time. Trillian’s contents are served from a data storage layer which enables its high scalability to very large trees. As an append-only log, Trillian is similar in technology to a blockchain. Developed at Google, Trillian was open-sourced in 2016. As Sigstore’s signature transparency log, Rekor requires running instances of Trillian's log server and signer, and relies on a database backend. If you ran your own Rekor instance in the previous chapter, you will have set up Trillian as part of that process. 
+
+In addition to informing Trillian and Sigstore, Certificate Transparency supported the development of other transparency projects. Notably, [Binary Transparency for Firefox](https://wiki.mozilla.org/Security/Binary_Transparency), which was published by Mozilla in 2017. This piggybacked off of existing Certificate Transparency logs and enabled third parties to verify that all Firefox binaries are public and that the same version was distributed to everyone without them having been compromised by some malicious actor. Built upon Firefox’s Binary Transparency was the project [rget](https://github.com/merklecounty/rget#rget), developed for general binary transparency. Created by Brandon Phillips in 2019, the project was archived in 2020, and a later project, [tl](https://github.com/transparencylog/tl), was sunset in 2021. 
+
+The transparency log work fed into the Rekor project which began in mid-2020. Luke Hinds, Bob Callaway, and Dan Lorenc are the co-founders of the Sigstore project, which launched in March 2021 with Rekor, Fulcio, and Cosign. The 1.0 version of Cosign was released on July 28, 2021, and general availability of Sigstore is imminent. 
+
+## Relevant Research
+
+* [Software Distribution Transparency and Auditability](https://arxiv.org/abs/1711.07278)
+* [Contour: A Practical System for Binary Transparency](https://arxiv.org/abs/1712.08427)
+* [Reproducible Builds: Break a log, good things come in trees](https://bora.uib.no/bora-xmlui/handle/1956/20411)
+* [Dependency Issues: Solving the World's Open-Source Software Security Problem](https://warontherocks.com/2022/05/dependency-issues-solving-the-worlds-open-source-software-security-problem/)
+
+Review also the [Software Supply-Chain Security Reading List](https://github.com/chainguard-dev/ssc-reading-list). 
+
+## Resources for Learning More
+
+Sigstore is a living open source project that is in active development with an engaged community. There are a number of places where you can look for updated information about Sigstore.
+
+The [Sigstore GitHub organization](https://github.com/sigstore/) with its relevant libraries for [Cosign](https://github.com/sigstore/cosign), [Fulcio](https://github.com/sigstore/fulcio), and [Rekor](https://github.com/sigstore/rekor) serve as a living source of truth for the Sigstore project and its components. The [Sigstore YouTube Channel](https://www.youtube.com/channel/UCWPVc8glVGOODxsA_ep0VVws) offers community talks and demos in addition to weekly community meetings. The [Sigstore Blog](https://blog.sigstore.dev/) also offers frequent posts about new changes, announcements, and technical overviews of Sigstore.
+
+If you would like more of a background about software supply chain security more generally, you can refer to the resources available through the [Software Supply-Chain Security Reading List](https://github.com/chainguard-dev/ssc-reading-list). If you are interested in how Sigstore relates to different programming language communities, you can join the relevant language channels on the [Sigstore Slack](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ). If you are interested in Python, you may review Dustin Ingram’s PyCon talk on [Securing the Open Source Software Supply Chain](https://www.youtube.com/watch?v=i1QqhGsbX6Y) and review the [sigstore/sigstore-python](https://github.com/sigstore/sigstore-python) repository. Ruby developers may be interested in learning more about [signing gems](https://docs.ruby-lang.org/en/2.1.0/Gem/Security.html) and reviewing the [sigstore/ruby-sigstore](https://github.com/sigstore/ruby-sigstore) repository. The Java community holds a regular [Sigstore Java](https://docs.google.com/document/d/1R7mL-IUrc2Z_LuOIvwDWshVuPQS_2VNE_cIQx4Oy5zw/edit) meeting.
+
+Sigstore is increasingly being adopted by Cloud Native Computing Foundation (CNCF) projects, including [Kubernetes as of their 1.24 release](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/), [Harbor as of their 2.5.0 release](https://goharbor.io/blog/cosign-2.5.0/), and [Flux as of their 0.26 Security Docs release](https://fluxcd.io/blog/2022/02/security-image-provenance/). This wide adoption has implications for DevOps engineers and the larger supply chain around software artifacts, their provenance, and the ability for them to be verified. 
+
+You can also take the Linux Foundation [LFS182x: Securing Your Software Supply Chain with Sigstore](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home), which is free on the edX platform, with a paid certificate option. 

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -5,39 +5,45 @@ category: 'About sigstore'
 position: 4
 ---
 
-_An earlier version of some of this material was published in Chapter 5 of the [Linux Foundation Sigstore course](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home)._
+Over 100 contributors have pushed over 2,800 commits to Sigstore since its founding. Contributors to the project represent over 20 different organizations, including Red Hat, Google, Chainguard, Purdue University, VMware, Twitter, Citi, Charm, Anchore, and Iron Bank. Today, Sigstore Cosign has over 2,300 GitHub Stars and Sigstore Rekor has more than 3 million log entries. Today, there are over 1,200 active members on the [public Slack channel](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ), and many contributors and end users regularly attend Sigstore community meetings.
 
-Since its founding, over 100 contributors pushed over 2,800 commits to the Sigstore open-source repository. These contributors hail from 20 different organizations, including Google, Red Hat, Chainguard, Purdue University, VMware, Twitter, Citi, Charm, Anchor, and Iron Bank. As an open-source project that is growing in popularity, Sigstore currently has over 2,000 GitHub Stars and the project has over 2.25 million log entries. Today, there are over 1,100 active members on the public Slack channel, and many who regularly attend the weekly Sigstore community meetings.
-
-## A Short History Leading to Sigstore
-
-In response to a man-in-the-middle attack through a misissued wildcard HTTPS certificate for google.com, Ben Laurie wrote on Google’s approach to mitigate this issue going forward through certificate transparency. In 2014, he published “[Certificate Transparency](https://certificate.transparency.dev/)” in ACM’s _Queue_ about the approach, which was in active development. With certificate transparency, certificates could be public and verifiable through append-only logs. Out of this work came the [Certificate Transparency](Certificate Transparency) project — an ecosystem to support making website certificate issuance more transparent and verifiable.  
-
-In 2015, the [Verifiable Data Structures](https://github.com/google/trillian/blob/master/docs/papers/VerifiableDataStructures.pdf) white paper was written by a team at Google (Adam Eijdenberg, Ben Laurie, and Al Cutter). This effort extended and generalized the ideas put forth by Laurie in his Certificate Transparency paper of 2014. The white paper discusses Verifiable Logs, Verifiable Maps, and Verifiable Log Backed Maps as data structures and provides the example of a Verifiable Database that leverages a Verifiable Log and a Verifiable Map. The Trillian project is an implementation of the ideas put forth in this white paper. 
-
-A transparent, scalable, and cryptographically verifiable data store, [Trillian](https://trillian.im/) implements a Merkle tree and can therefore cryptographically prove that a given record is in the log and also that the log has not been tampered with. A tampered log would be changed or have something deleted since a previous point in time. Trillian’s contents are served from a data storage layer which enables its high scalability to very large trees. As an append-only log, Trillian is similar in technology to a blockchain. Developed at Google, Trillian was open-sourced in 2016. As Sigstore’s signature transparency log, Rekor requires running instances of Trillian's log server and signer, and relies on a database backend. If you ran your own Rekor instance in the previous chapter, you will have set up Trillian as part of that process. 
-
-In addition to informing Trillian and Sigstore, Certificate Transparency supported the development of other transparency projects. Notably, [Binary Transparency for Firefox](https://wiki.mozilla.org/Security/Binary_Transparency), which was published by Mozilla in 2017. This piggybacked off of existing Certificate Transparency logs and enabled third parties to verify that all Firefox binaries are public and that the same version was distributed to everyone without them having been compromised by some malicious actor. Built upon Firefox’s Binary Transparency was the project [rget](https://github.com/merklecounty/rget#rget), developed for general binary transparency. Created by Brandon Phillips in 2019, the project was archived in 2020, and a later project, [tl](https://github.com/transparencylog/tl), was sunset in 2021. 
-
-The transparency log work fed into the Rekor project which began in mid-2020. Luke Hinds, Bob Callaway, and Dan Lorenc are the co-founders of the Sigstore project, which launched in March 2021 with Rekor, Fulcio, and Cosign. The 1.0 version of Cosign was released on July 28, 2021, and general availability of Sigstore is imminent. 
+The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. On July 28, 2021, the 1.0 version of Cosign was released, and the community is currently planning a general availability of Sigstore. 
 
 ## Relevant Research
+
+Academic and industry research related to software supply chain security, transparency, reproducibility, and more:
 
 * [Software Distribution Transparency and Auditability](https://arxiv.org/abs/1711.07278)
 * [Contour: A Practical System for Binary Transparency](https://arxiv.org/abs/1712.08427)
 * [Reproducible Builds: Break a log, good things come in trees](https://bora.uib.no/bora-xmlui/handle/1956/20411)
 * [Dependency Issues: Solving the World's Open-Source Software Security Problem](https://warontherocks.com/2022/05/dependency-issues-solving-the-worlds-open-source-software-security-problem/)
+* [Software Supply-Chain Security Reading List](https://github.com/chainguard-dev/ssc-reading-list)
 
-Review also the [Software Supply-Chain Security Reading List](https://github.com/chainguard-dev/ssc-reading-list). 
+## Sigstore and Programming Language Communities
+
+* Go: [sigstore/sigstore](https://github.com/sigstore/sigstore)
+* Python: 
+    * [sigstore/sigstore-python](https://github.com/sigstore/sigstore-python)
+    * [Securing the Open Source Software Supply Chain at PyCon](https://www.youtube.com/watch?v=i1QqhGsbX6Y)
+* Ruby: 
+    * [sigstore/ruby-sigstore](https://github.com/sigstore/ruby-sigstore)
+    * [Gems security](https://docs.ruby-lang.org/en/2.1.0/Gem/Security.html)
+* Java and Maven:
+    * [sigstore/java](https://github.com/sigstore/sigstore-java)
+    * [sigstore/sigstore-maven](https://github.com/sigstore/sigstore-maven)
+    * [Sigstore Java meeting notes](https://docs.google.com/document/d/1R7mL-IUrc2Z_LuOIvwDWshVuPQS_2VNE_cIQx4Oy5zw/edit)
+* Rust: [sigstore/sigstore-rs](https://github.com/sigstore/sigstore-rs)
 
 ## Resources for Learning More
 
-Sigstore is a living open source project that is in active development with an engaged community. There are a number of places where you can look for updated information about Sigstore.
+As a living open source project with an engaged community, there are a number of sites and platforms you can navigate to for updated information on Sigstore:
 
-The [Sigstore GitHub organization](https://github.com/sigstore/) with its relevant libraries for [Cosign](https://github.com/sigstore/cosign), [Fulcio](https://github.com/sigstore/fulcio), and [Rekor](https://github.com/sigstore/rekor) serve as a living source of truth for the Sigstore project and its components. The [Sigstore YouTube Channel](https://www.youtube.com/channel/UCWPVc8glVGOODxsA_ep0VVws) offers community talks and demos in addition to weekly community meetings. The [Sigstore Blog](https://blog.sigstore.dev/) also offers frequent posts about new changes, announcements, and technical overviews of Sigstore.
-
-If you would like more of a background about software supply chain security more generally, you can refer to the resources available through the [Software Supply-Chain Security Reading List](https://github.com/chainguard-dev/ssc-reading-list). If you are interested in how Sigstore relates to different programming language communities, you can join the relevant language channels on the [Sigstore Slack](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ). If you are interested in Python, you may review Dustin Ingram’s PyCon talk on [Securing the Open Source Software Supply Chain](https://www.youtube.com/watch?v=i1QqhGsbX6Y) and review the [sigstore/sigstore-python](https://github.com/sigstore/sigstore-python) repository. Ruby developers may be interested in learning more about [signing gems](https://docs.ruby-lang.org/en/2.1.0/Gem/Security.html) and reviewing the [sigstore/ruby-sigstore](https://github.com/sigstore/ruby-sigstore) repository. The Java community holds a regular [Sigstore Java](https://docs.google.com/document/d/1R7mL-IUrc2Z_LuOIvwDWshVuPQS_2VNE_cIQx4Oy5zw/edit) meeting.
-
-Sigstore is increasingly being adopted by Cloud Native Computing Foundation (CNCF) projects, including [Kubernetes as of their 1.24 release](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/), [Harbor as of their 2.5.0 release](https://goharbor.io/blog/cosign-2.5.0/), and [Flux as of their 0.26 Security Docs release](https://fluxcd.io/blog/2022/02/security-image-provenance/). This wide adoption has implications for DevOps engineers and the larger supply chain around software artifacts, their provenance, and the ability for them to be verified. 
-
-You can also take the Linux Foundation [LFS182x: Securing Your Software Supply Chain with Sigstore](https://learning.edx.org/course/course-v1:LinuxFoundationX+LFS182x+2T2022/home), which is free on the edX platform, with a paid certificate option. 
+* [Sigstore GitHub organization](https://github.com/sigstore/)
+    * [Cosign repository](https://github.com/sigstore/cosign)
+    * [Fulcio repository](https://github.com/sigstore/fulcio)
+    * [Rekor repository](https://github.com/sigstore/rekor)
+    * [Gitsign repository](https://github.com/sigstore/gitsign)
+    * [Policy Controller repository](https://github.com/sigstore/policy-controller)
+* [Sigstore YouTube Channel](https://www.youtube.com/channel/UCWPVc8glVGOODxsA_ep0VVws)
+* [Sigstore Blog](https://blog.sigstore.dev/) 
+* [Sigstore Slack](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -1,5 +1,5 @@
 ---
-title: "sigstore"
+title: "Sigstore"
 description: "Documentation for sigstore"
 category: "About sigstore"
 menuTitle: "Overview"
@@ -8,17 +8,25 @@ position: 1
 
 <img src="/sigstore_overview_v2.jpg" class="light-img" width="1280" height="640" alt=""/>
 
-**sigstore empowers software developers to securely sign software artifacts such as release files, container images, binaries, bill of material manifests and more. Signing materials are then stored in a tamper-resistant public log.**
+**Sigstore empowers software developers to securely sign software artifacts such as release files, container images, binaries, bill of material manifests and more. Signing materials are then stored in a tamper-resistant public log.**
 
-It’s free to use for all developers and software providers, with sigstore’s code and operational tooling being 100% open source, and everything maintained and developed by the sigstore community.
+It’s free to use for all developers and software providers, with Sigstore’s code and operational tooling being 100% open source, and everything maintained and developed by the Sigstore community.
 
-## How sigstore works
+## How to use Sigstore
 
-Using Fulcio, sigstore requests a certificate from our root Certificate Authority (CA). This checks you are who you say you are using OpenID Connect, which looks at your email address to prove you’re the author. Fulcio grants a time-stamped certificate, a way to say you’re signed in and that it’s you.
+* Sign software artifacts with [Cosign](/cosign/overview) — [Quick start](https://docs.sigstore.dev/cosign/overview#getting-started-quick-start)
+* Sign Git commits with [Gitsign](/gitsign/overview) - [Quick start](https://docs.sigstore.dev/gitsign/overview#quick-start)
+* Verify entries with [Rekor](/rekor/CLI#verify-proof-of-entry)
+* Use the [policy controller](/policy-controller/overview) to enfore Kubernetes policies
+* Use the [Fulcio Certificate Authority](/fulcio/overview)
 
-You don’t have to do anything with keys yourself, and sigstore never obtains your private key. The public key that Cosign creates gets bound to your certificate, and the signing details get stored in sigstore’s trust root, the deeper layer of keys and trustees and what we use to check authenticity.
+## How Sigstore works
 
-Your certificate then comes back to sigstore, where sigstore exchanges keys, asserts your identity and signs everything off. The signature contains the hash itself, public key, signature content and the time stamp. This all gets uploaded to a Rekor transparency log, so anyone can check that what you’ve put out there went through all the checks needed to be authentic.
+Using Fulcio, Sigstore requests a certificate from our root Certificate Authority (CA). This checks you are who you say you are using OpenID Connect, which looks at your email address to prove you’re the author. Fulcio grants a time-stamped certificate, a way to say you’re signed in and that it’s you.
+
+You don’t have to do anything with keys yourself, and Sigstore never obtains your private key. The public key that Cosign creates gets bound to your certificate, and the signing details get stored in Sigstore’s trust root, the deeper layer of keys and trustees and what we use to check authenticity.
+
+Your certificate then comes back to Sigstore, where Sigstore exchanges keys, asserts your identity and signs everything off. The signature contains the hash itself, public key, signature content and the time stamp. This all gets uploaded to a Rekor transparency log, so anyone can check that what you’ve put out there went through all the checks needed to be authentic.
 
 ## Software supply chain security
 
@@ -28,10 +36,10 @@ The tool sets we’ve historically relied on were not built for the present circ
 
 ## About the project
 
-sigstore is a Linux Foundation project backed by Google, Red Hat and Purdue University. We provide a public good, non-profit service to improve the open source software supply chain by easing the adoption of cryptographic software signing.
+Sigstore is a Linux Foundation project backed by Google, Red Hat and Purdue University. We provide a public good, non-profit service to improve the open source software supply chain by easing the adoption of cryptographic software signing.
 
 ## Contributing
 
-Up to date documentation, best practices and detailed scenarios for sigstore live here. These pages are maintained by the community and intended to help anyone get set up easily with any of the technologies, to find what you’re looking for fast. It’s also where we keep all the relevant pages for the sigstore trust root, from ceremonies to security practices.
+Up to date documentation, best practices and detailed scenarios for Sigstore live here. These pages are maintained by the community and intended to help anyone get set up easily with any of the technologies, to find what you’re looking for fast. It’s also where we keep all the relevant pages for the Sigstore trust root, from ceremonies to security practices.
 
-Ready to jump in? Check the contributing guidelines [here](/contributing).
+Ready to jump in? Check the [contributing guidelines](/contributing).

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -14,8 +14,8 @@ It’s free to use for all developers and software providers, with Sigstore’s 
 
 ## How to use Sigstore
 
-* Sign software artifacts with [Cosign](/cosign/overview) — [Quick start](https://docs.sigstore.dev/cosign/overview#getting-started-quick-start)
-* Sign Git commits with [Gitsign](/gitsign/overview) - [Quick start](https://docs.sigstore.dev/gitsign/overview#quick-start)
+* Sign software artifacts with [Cosign](/cosign/overview) — [Quick start](/cosign/overview#getting-started-quick-start)
+* Sign Git commits with [Gitsign](/gitsign/overview) - [Quick start](/gitsign/overview#quick-start)
 * Verify entries with [Rekor](/rekor/CLI#verify-proof-of-entry)
 * Use the [policy controller](/policy-controller/overview) to enfore Kubernetes policies
 * Use the [Fulcio Certificate Authority](/fulcio/overview)

--- a/content/en/main-concepts.md
+++ b/content/en/main-concepts.md
@@ -1,5 +1,5 @@
 ---
-title: "Main concepts"
+title: "Main Concepts"
 description: ""
 position: 2
 category: "About sigstore"
@@ -10,7 +10,7 @@ features:
   - OpenID Connect (means of authentication)
 ---
 
-sigstore combines several different technologies that focus on automatic key management and transparency logs. They can be used independently or as one single process, and together they create a safer chain of custody tracing software back to the source.
+Sigstore combines several different technologies that focus on automatic key management and transparency logs. They can be used independently or as one single process, and together they create a safer chain of custody tracing software back to the source.
 
 <list :items="features" type="info"></list>
 

--- a/content/en/security.md
+++ b/content/en/security.md
@@ -1,5 +1,5 @@
 ---
-title: 'Security model'
+title: 'Security Model'
 description: ''
 category: 'About sigstore'
 position: 3

--- a/content/settings.json
+++ b/content/settings.json
@@ -8,6 +8,6 @@
     "light": "/logo-light.svg",
     "dark": "/logo-dark.svg"
   },
-  "github": "sigstore/sigstore-website/tree/docs",
+  "github": "sigstore/sigstore-website",
   "twitter": "@projectsigstore"
 }


### PR DESCRIPTION
#### Summary

Resolves #93 and #156

I added a history and research page, some of this is being brought in from the Sigstore course and is attributed. I think that this could be expanded upon especially in terms of the research side, but I wanted to start the page and do a first pass.

I added practical links to the landing index page of the docs site. 

Additionally, I made some minor stylistic changes to make casing more consistent, and tried to fix some images that have gone missing.

#### Release Note

Docs changes

#### Documentation

These are exclusively docs changes