### PR TITLE
Fix links on docs.sigstore.dev/gitsign/usage page

### DIFF
--- a/content/en/gitsign/usage.md
+++ b/content/en/gitsign/usage.md
@@ -36,7 +36,7 @@ The following config options are supported:
 
 | Environment Variable      | Sigstore<br>Prefix | Default                          | Description                                                                                                                                                                                                                                |
 | ------------------------- | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| GITSIGN_CREDENTIAL_CACHE  | ❌                 |                                  | Optional path to [gitsign-credential-cache](cmd/gitsign-credential-cache/README.md) socket.                                                                                                                                                |
+| GITSIGN_CREDENTIAL_CACHE  | ❌                 |                                  | Optional path to [gitsign-credential-cache](https://github.com/sigstore/gitsign/tree/main/cmd/gitsign-credential-cache) socket.                                                                                                            |
 | GITSIGN_CONNECTOR_ID      | ✅                 |                                  | Optional Connector ID to auto-select to pre-select auth flow to use. For the public sigstore instance, valid values are:<br>- `https://github.com/login/oauth`<br>- `https://accounts.google.com`<br>- `https://login.microsoftonline.com` |
 | GITSIGN_FULCIO_URL        | ✅                 | https://fulcio.sigstore.dev      | Address of Fulcio server                                                                                                                                                                                                                   |
 | GITSIGN_LOG               | ❌                 |                                  | Path to log status output. Helpful for debugging when no TTY is available in the environment.                                                                                                                                              |
@@ -53,7 +53,7 @@ are set, `GITSIGN_` prefix takes priority.
 ## Signing a Commit
 
 After installing Gitsign and
-[configuring Git to use it as a signer application](/gitsign/installation#configuring-git-to-use-gitsign-for-signing)
+[configuring Git to use it as a signer application](/gitsign/installation#configuring-git-to-use-gitsign)
 for your project (or globally), you can sign commits as usual with
 `git commit -S` (or `git config --global commit.gpgsign true` to enable signing
 for all commits).


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Closes #217. This PR updates links on the [gitsign/usage page](https://docs.sigstore.dev/gitsign/usage) on the sigstore website.

#### Release Note

None.

#### Documentation

This is a documentation only update.
