### PR TITLE
Correct the link to the OCI media types

### DIFF
--- a/content/en/cosign/registry_support.md
+++ b/content/en/cosign/registry_support.md
@@ -22,7 +22,7 @@ Today, Cosign has been tested and works against the following registries:
 * Sonatype Nexus Container Registry
 * Alibaba Cloud Container Registry
 
-We aim for wide registry support. To sign images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/SPEC.md#object-types), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
+We aim for wide registry support. To sign images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md#object-types), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 
 ```shell
 COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The current https://docs.sigstore.dev/cosign/registry_support page refers to [OCI media types](https://github.com/sigstore/cosign/blob/main/SPEC.md#object-types), which is a link to a non-existent file due to changes in the repository. This correct the link to https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md#object-types

#### Release Note
NONE

#### Documentation
This is a documentation update.