### PR TITLE
Fix broken link

### DIFF
--- a/content/en/policy-controller/overview.md
+++ b/content/en/policy-controller/overview.md
@@ -11,7 +11,7 @@ The `policy-controller` admission controller can be used to enforce policy on a 
 
 `policy-controller` also resolves the image tags to ensure the image being ran is not different from when it was admitted.
 
-See the [installation instructions](installation) for more information.
+See the [installation instructions](/policy-controller/installation/) for more information.
 
 **This component is still actively under development!**
 


### PR DESCRIPTION
#### Summary

I haven't used Nuxt before, so there might be a better fix...

I noticed the current code `installation` redirects to `/policy-controller/overview/installation` (as a ref URL would? I think?) and we should point to `/policy-controller/installation/`.

Instead of digging into how Nuxt works, I updated the docs to use a `/` for an absolute path. I hope it works! 🤞 

#### Release Note

NONE

#### Netlify Preview

Click link for "See the installation instructions for more information."

https://deploy-preview-228--sigstore.netlify.app/policy-controller/overview