### PR TITLE
Add logo to community page

### DIFF
--- a/components/sponsorsList.vue
+++ b/components/sponsorsList.vue
@@ -5,6 +5,7 @@
                 <div class="flex items-center justify-center">
                     <img class="md:w-122 w-55 mr-20" src="/img/googlelogo.png" alt="Google sponsor logo" />
                     <img class="md:w-122 w-55 mr-20" src="/img/linuxfoundationlogo.png" alt="Linux Foundation sponsor logo" />
+                    <img class="md:w-122 w-55 md:mr-20" src="/img/chainguard.svg" alt="Chainguard sponsor logo" />
                     <img class="md:w-122 w-55 mr-20" src="/img/redhatlogo.png" alt="RedHat sponsor logo" />
                     <img class="md:w-122 w-55 mr-20" src="/img/purdueunilogo.png" alt="Purdue University sponsor logo" />
                 </div>


### PR DESCRIPTION
Resolves #249 as Chainguard was not included among the logos there but it is on the homepage