### PR TITLE
Update Slack link to a non-expiring one

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -27,7 +27,7 @@ sections:
         happening.
       ctaText: Join us on Slack
       bgColour: bg-white
-      ctaLink: https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A
+      ctaLink: https://sigstore.slack.com/join/shared_invite/zt-1z7jzpemb-xEKSUtpgDFXpIEMwMYZQKQ
     column2:
       header: Share your stories
       imageAsset: /img/stories.svg

--- a/content/community.md
+++ b/content/community.md
@@ -27,7 +27,7 @@ sections:
         happening.
       ctaText: Join us on Slack
       bgColour: bg-white
-      ctaLink: https://links.sigstore.dev/slack-invite
+      ctaLink: https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A
     column2:
       header: Share your stories
       imageAsset: /img/stories.svg

--- a/content/docs/what_is_sigstore.md
+++ b/content/docs/what_is_sigstore.md
@@ -115,7 +115,7 @@ Mostly for these reasons:
 sigstore is complementary to TUF / in-toto, and project members of the TUF / in-toto
 communities are collaborating with sigstore. For more details and the latest status
 please jump onto our [slack
-workplace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg).
+workplace](https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A).
 
 ### Do you plan to run a monitor?
 
@@ -126,7 +126,7 @@ Yes, we do in some form. Currently some folks from Purdue university are working
 Yes, very much! The more people monitoring the logs and rendering or providing useful services to users, the better.
 
 We have published OpenAPI interfaces for both [Rekor](https://sigstore.dev/swagger/index.html?urls.primaryName=Rekor) and [Fulcio](https://sigstore.dev/swagger/index.html?urls.primaryName=Fulcio)
-The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)
+The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A)
 to run your ideas past us.
 
 ### What is the current status of the project

--- a/content/docs/what_is_sigstore.md
+++ b/content/docs/what_is_sigstore.md
@@ -138,7 +138,7 @@ WebPKI (fuclio) and develop client tools for various package managers and upstre
 ## Want to find out more?
 
 * Come on over to our [slack
-workplace](https://join.slack.com/t/sigstore/shared_invite/zt-19g6gxfu9-G4rD1hrvFMr08uDc1_OtDg)
+workplace](https://sigstore.slack.com/join/shared_invite/zt-1z7jzpemb-xEKSUtpgDFXpIEMwMYZQKQ)
 * follow us on [twitter @projectsigstore](https://twitter.com/projectsigstore) (we are quite busy there with updates)
 * follow our [blog](https://blog.sigstore.dev)
 * join our mailing list at [sigstore-dev@googlegroups.com](https://groups.google.com/g/sigstore-dev)

--- a/content/docs/what_is_sigstore.md
+++ b/content/docs/what_is_sigstore.md
@@ -126,7 +126,7 @@ Yes, we do in some form. Currently some folks from Purdue university are working
 Yes, very much! The more people monitoring the logs and rendering or providing useful services to users, the better.
 
 We have published OpenAPI interfaces for both [Rekor](https://sigstore.dev/swagger/index.html?urls.primaryName=Rekor) and [Fulcio](https://sigstore.dev/swagger/index.html?urls.primaryName=Fulcio)
-The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A)
+The goal is to make it easier to integrate directly with sigstore services. You can always jump on our [slack workspace](https://sigstore.slack.com/join/shared_invite/zt-1z7jzpemb-xEKSUtpgDFXpIEMwMYZQKQ)
 to run your ideas past us.
 
 ### What is the current status of the project

--- a/content/faq/faqs.json
+++ b/content/faq/faqs.json
@@ -10,7 +10,7 @@
     },
     {
       "question": "How can I report security issues?",
-      "answer": "The best way is to try out the technologies and let us know your thoughts - it’ll help us keep developing sigstore’s functionality and see where we can improve. It grows the community too, and we’d always welcome new members to the working group over on Slack, https://links.sigstore.dev/slack-invite. You can also follow us on Twitter at @projectsigstore or the blog for updates, or join the mailing list at sigstore-dev@googlegroups.com."
+      "answer": "The best way is to try out the technologies and let us know your thoughts - it’ll help us keep developing sigstore’s functionality and see where we can improve. It grows the community too, and we’d always welcome new members to the working group over on Slack, https://sigstore.slack.com/join/shared_invite/zt-1z7jzpemb-xEKSUtpgDFXpIEMwMYZQKQ. You can also follow us on Twitter at @projectsigstore or the blog for updates, or join the mailing list at sigstore-dev@googlegroups.com."
     },
     {
       "question": "How easy is it to use?",

--- a/content/setup/connect.json
+++ b/content/setup/connect.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Slack",
-      "url": "https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A"
+      "url": "https://sigstore.slack.com/join/shared_invite/zt-1z7jzpemb-xEKSUtpgDFXpIEMwMYZQKQ"
     }
   ]
 }

--- a/content/setup/connect.json
+++ b/content/setup/connect.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Slack",
-      "url": "https://links.sigstore.dev/slack-invite"
+      "url": "https://join.slack.com/t/sigstore/shared_invite/zt-21ky9s4ur-04bhXrTgIimboJgLx3QB2A"
     }
   ]
 }


### PR DESCRIPTION
## What
Update the invite link for Slack

## Why
Previous one had expired.

Updates Slack links to a new one that has no expiry

Signed-off-by: Trevor Rosen <trevrosen@github.com>