### PR TITLE
More capitalization changes

### DIFF
--- a/components/sigstoreEcosystem.vue
+++ b/components/sigstoreEcosystem.vue
@@ -2,7 +2,7 @@
 <template>
     <section class="py-64 md:py-128 bg-white" data-header-text="text-gray-dark">
         <div class="text-gray-dark container inner text-center">
-            <h3 class="text-36 pb-44">The sigstore ecosystem</h3>
+            <h3 class="text-36 pb-44">The Sigstore ecosystem</h3>
             <div class="flex justify-start md:justify-center items-start mb-64 overflow-x-scroll md:overflow-x-visible relative">
                 <button
                     v-for="(group, index) in groupTabs" 

--- a/content/docs/about.md
+++ b/content/docs/about.md
@@ -6,7 +6,7 @@ section: single
 type: page
 ---
 
-The following guide is targeted towards developers / software maintainers who would like to make a provenance entry into the rekor transparency log.
+The following guide is targeted towards developers / software maintainers who would like to make a provenance entry into the Rekor transparency log.
 
 The steps outlined below will show how to sign your software and then use the `rekor` CLI to make and verify an entry.
 
@@ -16,7 +16,7 @@ The steps outlined below will show how to sign your software and then use the `r
 
 You will of course also need golang version 1.15 or greater and a `$GOPATH` set.
 
-## Build rekor
+## Build Rekor
 
 ```
 go get -u -t -v github.com/sigstore/rekor/cmd/rekor-cli
@@ -27,7 +27,7 @@ cp rekor /usr/local/bin/
 
 ## Sign your release
 
-Before using rekor, you are required to sign your release. The following example illustrates
+Before using Rekor, you are required to sign your release. The following example illustrates
 this using GPG.
 
 You may use either armored or plain binary:
@@ -42,9 +42,9 @@ You will also need to export your public key
 gpg --export --armor "jdoe@example.com" > mypublickey.key
 ```
 
-## Upload an entry rekor
+## Upload an entry Rekor
 
-The `upload` command sends your public key / signature and artifact URL to the rekor transparency log.
+The `upload` command sends your public key / signature and artifact URL to the Rekor transparency log.
 
 ```
 rekor upload --rekor_server https://rekor.sigstore.dev --signature <artifact_signature> --public-key <your_public_key> --artifact <url_to_artifact>
@@ -54,7 +54,7 @@ Firstly the rekor command will verify your public key, signature and download
 a local copy of the artifact. It will then validate the artifact signing (no
 access to your private key is required).
 
-If the validations above pass correctly, the entry will be made to rekor and an entry URL will be returned:
+If the validations above pass correctly, the entry will be made to Rekor and an entry URL will be returned:
 
 ```
 Created entry at: https://rekor.sigstore.dev/api/v1/log/entries/b08416d417acdb0610d4a030d8f697f9d0a718024681a00fa0b9ba67072a38b5
@@ -66,7 +66,7 @@ Within here is again the UUID and the body of the entry.
 
 ## Verify Proof of Entry
 
-The `verify` command allows you to send a public key / signature and artifact to the rekor transparency log for verification of entry.
+The `verify` command allows you to send a public key / signature and artifact to the Rekor transparency log for verification of entry.
 
 You would typically use this command as a means to verify an 'inclusion proof'
 showing that your artifact is stored within the transparency log.
@@ -100,7 +100,7 @@ rekor loginfo --rekor_server https://rekor.sigstore.dev
 
 ## Search
 
-If running a redis instance within rekor, the `search` command performs a redis lookup using a file or a public key.
+If running a redis instance within Rekor, the `search` command performs a redis lookup using a file or a public key.
 
 This command requires one of an artifact, a public key, or a SHA hash.
 

--- a/content/docs/docs/api_example.md
+++ b/content/docs/docs/api_example.md
@@ -6,6 +6,6 @@ section: single
 type: page
 ---
 
-We use the [OpenAPI specification](https://swagger.io/docs/specification/about/) in rekor making it easy to create your own RestFul API client.
+We use the [OpenAPI specification](https://swagger.io/docs/specification/about/) in Rekor making it easy to create your own RestFul API client.
 
 If you're interested in developing an application that can store or retrieve entries into a Rekor transparency log, we recommend you take a look at the [swagger online editor](https://sigstore.dev/swagger/index.html?urls.primaryName=Rekor).

--- a/content/docs/get_started/client.md
+++ b/content/docs/get_started/client.md
@@ -6,7 +6,7 @@ section: single
 type: page
 ---
 
-The following guide is targeted towards developers / software maintainers who would like to make a provenance entry into the rekor transparency log.
+The following guide is targeted towards developers / software maintainers who would like to make a provenance entry into the Rekor transparency log.
 
 The steps outlined below will show how to sign your software and then use the `rekor` CLI to make and verify an entry.
 
@@ -16,7 +16,7 @@ The steps outlined below will show how to sign your software and then use the `r
 
 You will of course also need golang version 1.15 or greater and a `$GOPATH` set.
 
-## Build rekor
+## Build Rekor
 
 ```
 go get -u -t -v github.com/sigstore/rekor/cmd/rekor-cli
@@ -27,7 +27,7 @@ cp rekor /usr/local/bin/
 
 ## Sign your release
 
-Before using rekor, you are required to sign your release. The following example illustrates
+Before using Rekor, you are required to sign your release. The following example illustrates
 this using GPG.
 
 You may use either armored or plain binary:
@@ -42,19 +42,19 @@ You will also need to export your public key
 gpg --export --armor "jdoe@example.com" > mypublickey.key
 ```
 
-## Upload an entry rekor
+## Upload an entry Rekor
 
-The `upload` command sends your public key / signature and artifact URL to the rekor transparency log.
+The `upload` command sends your public key / signature and artifact URL to the Rekor transparency log.
 
 ```
 rekor upload --rekor_server https://rekor.sigstore.dev --signature <artifact_signature> --public-key <your_public_key> --artifact <url_to_artifact>
 ```
 
-Firstly the rekor command will verify your public key, signature and download
+Firstly the Rekor command will verify your public key, signature and download
 a local copy of the artifact. It will then validate the artifact signing (no
 access to your private key is required).
 
-If the validations above pass correctly, the entry will be made to rekor and an entry URL will be returned:
+If the validations above pass correctly, the entry will be made to Rekor and an entry URL will be returned:
 
 ```
 Created entry at: https://rekor.sigstore.dev/api/v1/log/entries/b08416d417acdb0610d4a030d8f697f9d0a718024681a00fa0b9ba67072a38b5
@@ -66,7 +66,7 @@ Within here is again the UUID and the body of the entry.
 
 ## Verify Proof of Entry
 
-The `verify` command allows you to send a public key / signature and artifact to the rekor transparency log for verification of entry.
+The `verify` command allows you to send a public key / signature and artifact to the Rekor transparency log for verification of entry.
 
 You would typically use this command as a means to verify an 'inclusion proof'
 showing that your artifact is stored within the transparency log.
@@ -100,7 +100,7 @@ rekor loginfo --rekor_server https://rekor.sigstore.dev
 
 ## Search
 
-If running a redis instance within rekor, the `search` command performs a redis lookup using a file or a public key.
+If running a redis instance within Rekor, the `search` command performs a redis lookup using a file or a public key.
 
 This command requires one of an artifact, a public key, or a SHA hash.
 

--- a/content/docs/rekor_directory.md
+++ b/content/docs/rekor_directory.md
@@ -6,7 +6,7 @@ section: single
 type: page
 ---
 
-A list of current public instances of rekor
+A list of current public instances of Rekor
 
 | Server                                                               | Purpose |
 | -------------------------------------------------------------------- | ------- |

--- a/content/docs/what_is_sigstore.md
+++ b/content/docs/what_is_sigstore.md
@@ -38,13 +38,13 @@ current tooling (outside of controlled environments) all too often [feel inappro
 transparency logs.
 
 Users generate ephemeral short-lived key pairs using the sigstore client tooling. The sigstore PKI service will then
-provide a signing certificate generated upon a successful OpenID connect grant. All certificates are recorded into a
+provide a signing certificate generated upon a successful OpenID Connect grant. All certificates are recorded into a
 certificate transparency log and software signing materials are sent to a signature transparency log. The use of
 transparency logs introduces a trust root to the user's OpenID account. We can then have guarantees that the claimed
 user was in control of an identity service provider's account at the time of signing. Once the signing operation is
 complete, the keys can be discarded, removing any need for further key management or need to revoke or rotate.
 
-Using OpenID connect identities allows users to take advantage of existing security controls such as 2FA, OTP
+Using OpenID Connect identities allows users to take advantage of existing security controls such as 2FA, OTP
 and hardware token generators.
 
 sigstore's transparency logs can act as a source of provenance, integrity, and discoverability. Being public
@@ -79,11 +79,11 @@ At present the WebPKI and client signing tooling is under prototype development 
 
 ### Can I use the transparency log on its own?
 
-Sure, anyone can stand up a rekor instance (rekor is the name of the transparency log project under sigstore). We
+Sure, anyone can stand up a Rekor instance (Rekor is the name of the transparency log project under sigstore). We
 originally planned to just run a t-log, but then we realised not many were likely to use it as the whole signing UX [is
 less than desirable](https://latacora.micro.blog/2019/07/16/the-pgp-problem.html). So we extended the project to include
-an 'easy to use' signing system. So we very much intend to keep rekor in its current state where it can be run in on its
-own. So if you perform your own signing, you can just use rekor on its own.
+an 'easy to use' signing system. So we very much intend to keep Rekor in its current state where it can be run in on its
+own. So if you perform your own signing, you can just use Rekor on its own.
 
 Rekor has a pluggable PKI and support present for the following:
 
@@ -91,14 +91,14 @@ Rekor has a pluggable PKI and support present for the following:
 * X.509
 * Minisign
 
-It also has a customizable manifest schema (pluggable types), so you can get rekor to work with whatever values you need
+It also has a customizable manifest schema (pluggable types), so you can get Rekor to work with whatever values you need
 (within reason).
 
 More details of pluggable types can be found on the related [documentation page](../docs/plugable_types).
 
-Documentation on running a rekor server [is available here](../get_started/server).
+Documentation on running a Rekor server [is available here](../get_started/server).
 
-Documentation on the rekor client CLI (for adding an entry to a rekor transparency log) [is available here](../get_started/client).
+Documentation on the Rekor client CLI (for adding an entry to a Rekor transparency log) [is available here](../get_started/client).
 
 ### Why not blockchain?
 
@@ -131,7 +131,7 @@ to run your ideas past us.
 
 ### What is the current status of the project
 
-As of time of writing [24/06/2021] we have a working transparency log (rekor), that is fully operation as a standalone
+As of time of writing [24/06/2021] we have a working transparency log (Rekor), that is fully operation as a standalone
 service. Files are available to run this in GKE. Work is now underway to mature the
 WebPKI (fuclio) and develop client tools for various package managers and upstream communities
 


### PR DESCRIPTION
#### Summary
Sigstore capitalization was fixed in #338. This PR fixes one stray use of "sigstore" and all the inappropriate uses of uncapitalized versions of the other projects (cosign, fulcio, etc)

Partially addresses #334 .

#### Release Note
None

#### Documentation
I am going to do another pass on the documentation for un-capitalized project terms. 